### PR TITLE
Minor updates to explain changes to DR5 ccds-annotated file

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,10 @@
 
 - No changes yet.
 
+## 5.0.1 (DR5, 2017-12-7)
+
+- Update to ccds-annotated file to fix which CCDs were used in DR5.
+
 ## 5.0.0 (DR5, 2017-10-25)
 
 - Updated to release version for DR5 ([PR#73](https://github.com/legacysurvey/legacysurvey/pull/73)).

--- a/pages/dr5/files.rst
+++ b/pages/dr5/files.rst
@@ -257,9 +257,12 @@ Column               Type       Description
 ``psf_sampling``     float32    (ignore)
 ``ccd_cuts``         int32      (ignore)
 ``annotated``	     boolean    (ignore)
+``new_photometric``  boolean    see the ``Update to ccds-annotated- file...`` note on the `issues page`_
 ==================== ========== ======================================================
 
 .. _`status page`: ../../status
+.. _`issues page`: ../issues
+
 
 dr5-depth.fits.gz
 -----------------

--- a/pages/dr5/issues.rst
+++ b/pages/dr5/issues.rst
@@ -46,7 +46,7 @@ CCDs covering regions like CCD N26 in the figure would be dropped from DR5.
    :scale: 85
 
 Update to ``ccds-annotated-`` file in early December, 2017
-=====================================================================
+==========================================================
 
 The ``ccds-annotated-dr5.fits.gz`` file provided with the original DR5 release included a 
 ``photometric`` binary column that was computed based on zeropoints from our "traditional" IDL 
@@ -55,7 +55,7 @@ code to produce zeropoints, and we performed a photometric cut based on those ze
 result, some CCDs that appeared in the original ``ccds-annotated-dr5.fits.gz`` file with 
 the ``photometric`` flag set to ``True`` were *not* actually used in the DR5 reductions.
 
-The updated ``ccds-annotated-dr5.fitz.gz`` file (replaced in early December 2017)
+The updated ``ccds-annotated-dr5.fits.gz`` file (replaced in early December 2017)
 includes a new column, ``new_photometric``, that contains the correct set of CCDs used in
 the DR5 reductions. In addition, there were 228 CCDs for which annotations were not 
 computed in the original file, and these are added in the update.

--- a/pages/dr5/issues.rst
+++ b/pages/dr5/issues.rst
@@ -55,7 +55,10 @@ code to produce zeropoints, and we performed a photometric cut based on those ze
 result, some CCDs that appeared in the original ``ccds-annotated-dr5.fits.gz`` file with 
 the ``photometric`` flag set to ``True`` were *not* actually used in the DR5 reductions.
 
-The updated ``ccds-annotated-dr5.fits.gz`` file (replaced in early December 2017)
+The updated ``ccds-annotated-dr5.fits.gz`` file (replaced on December 7th, 2017)
 includes a new column, ``new_photometric``, that contains the correct set of CCDs used in
 the DR5 reductions. In addition, there were 228 CCDs for which annotations were not 
 computed in the original file, and these are added in the update.
+
+The original ``ccds-annotated-`` file is still available in the DR5 release directory. It
+has been renamed to ``ccds-annotated-dr5-2017-12-07.fits.gz``.

--- a/pages/dr5/issues.rst
+++ b/pages/dr5/issues.rst
@@ -44,3 +44,18 @@ CCDs covering regions like CCD N26 in the figure would be dropped from DR5.
    :height: 500
    :width: 700
    :scale: 85
+
+Update to ``ccds-annotated-`` file in early December, 2017
+=====================================================================
+
+The ``ccds-annotated-dr5.fits.gz`` file provided with the original DR5 release included a 
+``photometric`` binary column that was computed based on zeropoints from our "traditional" IDL 
+zeropoints code.  However, during DR5 processing we used our new Python-based ``legacyzpts`` 
+code to produce zeropoints, and we performed a photometric cut based on those zeropoints.  As a 
+result, some CCDs that appeared in the original ``ccds-annotated-dr5.fits.gz`` file with 
+the ``photometric`` flag set to ``True`` were *not* actually used in the DR5 reductions.
+
+The updated ``ccds-annotated-dr5.fitz.gz`` file (replaced in early December 2017)
+includes a new column, ``new_photometric``, that contains the correct set of CCDs used in
+the DR5 reductions. In addition, there were 228 CCDs for which annotations were not 
+computed in the original file, and these are added in the update.


### PR DESCRIPTION
Updates to DR5 issues and files page to explain recalculation of which CCDs contribute to DR5 in the ccds-annotated file