### PR TITLE
additional DR8 documentation updates

### DIFF
--- a/pages/dr8/external.rst
+++ b/pages/dr8/external.rst
@@ -38,7 +38,8 @@ Tycho-2
 External Catalogs used for Masking
 ==================================
 
-External catalogs are used for masking regions near foreground sources in DR8 (e.g. to construct ``BRIGHTBLOB`` on the `bitmasks page`_).
+External catalogs are used for masking regions near foreground sources in DR8
+(e.g. to construct ``BRIGHTBLOB`` and ``MASKBITS`` on the `bitmasks page`_).
 These catalogs are available to collaborators in the indicated directories at NERSC.
 
 "BRIGHT" stars
@@ -54,9 +55,15 @@ These catalogs are available to collaborators in the indicated directories at NE
 |     Medium-bright stars are also defined starting with all sources in the Tycho-2 catalog cut to ``MAG_VT`` < 13.  All such Tycho-2 stars have the ``MEDIUM`` bit set. In addition, Gaia DR2 sources with ``phot_g_mean_mag`` < 16 have the ``MEDIUM`` bit set, provided they do not already match a Tycho-2 source (where the match accounts for proper motion). Note that this means that all ``BRIGHT`` stars also have the ``MEDIUM`` bit set. The specific (Gaia G) magnitude-radius relationship is `hardcoded in legacypipe`_.
 
 
-Globular Clusters
------------------
-| The globular cluster catalog used for foreground masking is taken from `Mattia Verga's NGC/IC objects database`_. More specifically the catalog used to set the ``CLUSTER`` bit on the `bitmasks page`_ is `embedded within the legacypipe product itself`_.
+Globular Clusters & Planetary Nebulae
+-------------------------------------
+
+| In DR8 we mask globular clusters and planetary nebulae selected from the
+`OpenNGC`_ catalog of NGC/IC objects.  Specifically, we select all objects
+classified as ``GCl`` or ``PN`` and use a circular mask with a diameter taken
+from the ``majax`` attribute of this catalog.  The input catalog `can be found
+in the legacypipe software product`_.  Objects in this mask are given the
+``CLUSTER`` bit on the `bitmasks page`_  
 |
 
 LSLGA Large Galaxies
@@ -66,8 +73,8 @@ LSLGA Large Galaxies
 
 
 .. _`bitmasks page`: ../bitmasks
-.. _`embedded within the legacypipe product itself`: https://github.com/legacysurvey/legacypipe/blob/master/py/legacypipe/data/NGC-star-clusters.fits
+.. _`can be found in the legacypipe software product`: https://github.com/legacysurvey/legacypipe/blob/master/py/legacypipe/data/NGC-star-clusters.fits 
 .. _`hardcoded in legacypipe`: https://github.com/legacysurvey/legacypipe/blob/63d0548602a52be1134f64196d6268adc68208fb/py/legacypipe/reference.py#L196
-.. _`Mattia Verga's NGC/IC objects database`: https://github.com/mattiaverga/OpenNGC
+.. _`OpenNGC`: https://github.com/mattiaverga/OpenNGC
 .. _`Legacy Survey Large Galaxy Atlas (LSLGA) work`: https://github.com/moustakas/LSLGA
 .. _`the HyperLeda catalog`: http://leda.univ-lyon1.fr/acknowledge.html

--- a/pages/dr8/issues.rst
+++ b/pages/dr8/issues.rst
@@ -53,10 +53,17 @@ The fix, which will be included in DR9, is to force all reference stars (such as
 Bricks that didn't finish processing
 ------------------------------------
 Bricks that didn't finish processing, or that only partially
-completed because we "bailed out" of source-fitting can fail after the coadded images have been produced but before sources have been extracted.
-For such bricks, we remove any images from the ``coadd/`` directory so that the pixel-level files are consistent with the catalog-level files. This means that
-there are a small number of bricks in DR8 which have images loaded in the `viewer`_ but that do not have corresponding `files`_, `coadd files`_ 
-or `Tractor catalogs`_.
+completed because we "bailed out" of source-fitting can fail after the coadded
+images have been produced but before sources have been extracted.
+
+Most of these cases consist of bricks containing particularly large galaxies
+(e.g., `Andromeda`_), globular clusters (e.g., `M13`_), or bright stars.
+
+For such bricks, we remove any images from the ``coadd/`` directory so that the
+pixel-level files are consistent with the catalog-level files. This means that
+there are a small number of bricks in DR8 which have images loaded in the
+`viewer`_ but that do not have corresponding `files`_, `coadd files`_ or
+`Tractor catalogs`_.
 
 .. _`to fix a different bug in the reduction process`: https://github.com/legacysurvey/legacypipe/commit/a10ecc33247ec615ec1d8401cef2e0787f91a8fc
 .. _`Legacy Surveys website`: https://github.com/legacysurvey/legacysurvey/issues
@@ -67,3 +74,6 @@ or `Tractor catalogs`_.
 .. _`coadd files`: ../files/#image-stacks-region-coadd
 .. _`files`: ../files
 .. _`viewer`: http://legacysurvey.org/viewer
+.. _`Andromeda`: http://legacysurvey.org/viewer?ra=10.6801&dec=41.2757&zoom=10&layer=dr8
+.. _`M13`: http://legacysurvey.org/viewer?ra=250.4306&dec=36.4666&zoom=10&layer=dr8
+


### PR DESCRIPTION
Added some additional details on the `CLUSTER` external catalog and on when we bailed out on large galaxies.