### PR TITLE
Some additional clarifications for DR8

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,7 @@
 
 ## 8.0.2 (DR8, 2019-10-10)
 
-- Add DR8 forced photometry, clarify bitmask/CCD ordering descriptions:
+- Add DR8 forced photometry, clarify bitmasks/CCD ordering/patching:
   ([PR#103](https://github.com/legacysurvey/legacysurvey/pull/103),
   [PR#104](https://github.com/legacysurvey/legacysurvey/pull/104)).
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,7 @@
 
 ## 8.0.2 (DR8, 2019-10-10)
 
-- Add DR8 forced photometry, fix issues to clarify unclear descriptions:
+- Add DR8 forced photometry, clarify bitmask/CCD ordering descriptions:
   ([PR#103](https://github.com/legacysurvey/legacysurvey/pull/103),
   [PR#104](https://github.com/legacysurvey/legacysurvey/pull/104)).
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # legacysurvey Change Log
 
+## 8.0.2 (DR8, 2019-10-10)
+
+- Add DR8 forced photometry, fix issues to clarify unclear descriptions:
+  ([PR#103](https://github.com/legacysurvey/legacysurvey/pull/103),
+  [PR#104](https://github.com/legacysurvey/legacysurvey/pull/104)).
 
 ## 8.0.1 (DR8, 2019-07-31)
 

--- a/pages/ccdordering.rst
+++ b/pages/ccdordering.rst
@@ -32,4 +32,6 @@ In the table, ``0`` denotes [``ra0``, ``dec0``], ``1`` denotes [``ra1``, ``dec1`
 | 	   |``0   1``|
 +----------+---------+
 
+Note that for 2084 MzLS exposures the column ordering is reversed. These exposures were taken when the telescope was pointing at 
+hour angles (h.a.) of more than 6 hours; specifically at locations beyond the great circle that passes through the north celestial pole and the points Dec = 0, h.a. = +/- 6h.
 

--- a/pages/dr8/bitmasks.rst
+++ b/pages/dr8/bitmasks.rst
@@ -40,7 +40,7 @@ and sweeps catalogs. See also the `legacypipe bitmask definitions`_.
 Bit Name          Description
 === ============= ===============================
 0   ``NPRIMARY``  touches a pixel that is outside the ``BRICK_PRIMARY`` region of a brick
-1   ``BRIGHT``    touches a pixel in a blob containing a bright (Tycho-2) star
+1   ``BRIGHT``    touches a pixel within the locus of a `radius-magnitude relation for Tycho-2 stars`_ or one `for (G < 13) Gaia DR2 stars`_
 2   ``SATUR_G``   touches a pixel that was saturated in at least one :math:`g`-band image
 3   ``SATUR_R``   touches a pixel that was saturated in at least one :math:`r`-band image
 4   ``SATUR_Z``   touches a pixel that was saturated in at least one :math:`z`-band image
@@ -50,11 +50,14 @@ Bit Name          Description
 8   ``WISEM1``    touches a pixel in a ``WISEMASK_W1`` bright star mask
 9   ``WISEM2``    touches a pixel in a ``WISEMASK_W2`` bright star mask
 10  ``BAILOUT``   touches a pixel in a blob where we "bailed out" of source fitting
-11  ``MEDIUM``    touches a pixel in a medium-bright (`Gaia`_ DR2) star
+11  ``MEDIUM``    touches a pixel within the locus of a `radius-magnitude relation for (13 < G < 16) Gaia DR2 stars`_
 12  ``GALAXY``    touches a pixel in an `LSLGA`_ large galaxy
 13  ``CLUSTER``   touches a pixel in a globular cluster
 === ============= ===============================
 
+.. _`radius-magnitude relation for Tycho-2 stars`: https://github.com/legacysurvey/legacypipe/blob/65d71a6b0d0cc2ab94d497770346ff6241020f80/py/legacypipe/reference.py#L258
+.. _`for (G < 13) Gaia DR2 stars`: https://github.com/legacysurvey/legacypipe/blob/65d71a6b0d0cc2ab94d497770346ff6241020f80/py/legacypipe/reference.py#L196
+.. _`radius-magnitude relation for (13 < G < 16) Gaia DR2 stars`: https://github.com/legacysurvey/legacypipe/blob/65d71a6b0d0cc2ab94d497770346ff6241020f80/py/legacypipe/reference.py#L196
 .. _`Gaia`: https://gea.esac.esa.int/archive/documentation//GDR2/Gaia_archive/chap_datamodel/sec_dm_main_tables/ssec_dm_gaia_source.html
 .. _`LSLGA`: ../external
 

--- a/pages/dr8/issues.rst
+++ b/pages/dr8/issues.rst
@@ -32,7 +32,7 @@ Patching Morphological Models
 Some morphological quantities are inconsistent for PSF sources in DR8, due to a bug in the model selection function that was introduced
 on May 13th, 2019 `to fix a different bug in the reduction process`_.
 
-This issue occurs when the ``REX`` model is better than the ``PSF`` model, but not by *enough*.  In this case, instead of reverting to ``PSF``, the modeling code reverts to NONE.
+This issue occurs when the ``REX`` model is better than the ``PSF`` model, but not by more than a ``DCHISQ`` value of 1%.  In that case, instead of reverting to ``PSF``, the modeling code reverts to NONE.
 
 The upshot of this issue is that when ``REX`` is better than ``PSF``, but not by a sufficiently large margin, then the ``EXP`` or ``DEV`` model would be chosen instead of the ``PSF`` model.
 
@@ -47,6 +47,9 @@ for a patched source during extraction, affecting the fitting of other sources i
     - ``ANYMASK``, ``ALLMASK``, ``MASKBITS``, ``BRIGHTBLOB``, ``NOBS``.
 - Quantities that *will* be inconsistent as they will still use the ``DEV`` or ``EXP`` model shape:
     - ``FIBERFLUX``, ``FRACIN``, ``FRACFLUX``, ``FRACMASKED``, ``RCHISQ`` and the WISE forced photometry.
+
+DR8 was processed with several different code versions. Morphological models were only patched for a subset of the files that were
+processed with version DR8.2.1 of the code. These files can be identified by the header card: ``PATCHED`` `(= integer number of sources patched)`.
 
 The brightest stars are missing from models and catalogs
 --------------------------------------------------------


### PR DESCRIPTION
Includes:

- Note that the column ordering for CCDs is reversed for some MzLS exposures.
- Better description of the `BRIGHT`/`MEDIUM` masks in `MASKBITS`.
- Extra information about the "patched" morphological models and how they can be identified from the `PATCHED` header keyword.

Addresses #102.