### PR TITLE
Update some "Coming Soon" sections for DR9, and some general clean-up.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,11 @@
 
 ## 9.0.2 (DR9, unreleased)
 
+- Update some "Coming Soon" sections for DR9, now that they're released
+  ([PR#133](https://github.com/legacysurvey/legacysurvey/pull/133)). Includes:
+    - Update description of foreground masking files.
+    - Add data model for photoz sweeps (and update Zhou et al. reference).
+    - Also fix broken cutout server links, and update BASS contacts.
 - First version of SGA-2020 documentation
   ([PR#132](https://github.com/legacysurvey/legacysurvey/pull/132)).
 

--- a/pages/acknowledgment.rst
+++ b/pages/acknowledgment.rst
@@ -39,8 +39,8 @@ and "unWISE / NASA/JPL-Caltech / D. Lang (Perimeter Institute)" for unWISE layer
 from the image footage. Links should be active if the credit is online.
 
 
-Scientific Publication Acknowledgement
-======================================
+Scientific Publication Acknowledgment
+=====================================
 
 When using data from the Legacy Surveys in papers, please use the following acknowledgment:
 

--- a/pages/contact.rst
+++ b/pages/contact.rst
@@ -19,11 +19,15 @@ DECaLS and MzLS Principal Investigators:
     * David Schlegel djschlegel@lbl.gov
     * Arjun Dey dey@noao.edu
 
+BASS Survey:
+    * Xu Zhou (China PI) zhouxu@bao.ac.cn
+    * Xiaohui Fan (US PI)  fan@as.arizona.edu
+    * Hu Zou (Deputy PI) zouhu@bao.ac.cn
+    * BASS collaboration http://batc.bao.ac.cn/BASS/doku.php
+
 DESI Imaging Survey Scientist and Lead Tractor Developer:
     * Dustin Lang dstndstn@gmail.com
 
-BASS Survey:
-    * http://batc.bao.ac.cn/BASS/doku.php
 
 Other Experts
 -------------
@@ -64,7 +68,7 @@ Image Gallery:
     * John Moustakas  jmoustakas@siena.edu
     * Benjamin Weaver  baweaver@lbl.gov
 
-Siena Galaxy Atlas:
+`Siena Galaxy Atlas`_:
     * John Moustakas  jmoustakas@siena.edu
 
 Photometric Redshifts:
@@ -78,6 +82,7 @@ Pan-STARRS1 Catalogs:
     * Doug Finkbeiner  dfinkbeiner@cfa.harvard.edu
 
 .. _`Legacypipe`: https://legacypipe.readthedocs.io/en/latest/
+.. _`Siena Galaxy Atlas`: ../sga
 
 Additional contributors
 -----------------------

--- a/pages/dr8/files.rst
+++ b/pages/dr8/files.rst
@@ -695,11 +695,11 @@ Name                                  Type         Units                 Descrip
 Photometric Redshift files (8.0-photo-z/sweep-<brickmin>-<brickmax>-pz.fits)
 ----------------------------------------------------------------------------
 
-The Photometric Redshifts for the Legacy Surveys (PRLS, `Zhou et al. 2020`_)
+The Photometric Redshifts for the Legacy Surveys (PRLS, `Zhou et al. 2021`_)
 catalog is line-matched to the DR8 sweep catalogs as described above.
 
 The photometric redshifts are computed using the random forest algorithm.
-Details of the photo-z training and performance can be found in `Zhou et al. (2020)`_.
+Details of the photo-z training and performance can be found in `Zhou et al. (2021)`_.
 For computing the photo-z's, we require at least one exposure in
 :math:`g`, :math:`r` and :math:`z` bands (``NOBS_G,R,Z>1``).
 For objects that do not meet the NOBS cut,
@@ -713,7 +713,7 @@ The photo-z catalogs do not provide information on star-galaxy separation.
 Stars are excluded from the photo-z training data, and we do not attempt to
 identify stars. To perform star-galaxy separation, one can use the
 morphological "TYPE" and/or the photometry (*e.g.*, the optical-WISE
-color cut, as applied in  `Zhou et al. 2020`_, can be very effective for selecting redshift |gtapprox| 0.3 galaxies) in the sweep catalogs.
+color cut, as applied in  `Zhou et al. 2021`_, can be very effective for selecting redshift |gtapprox| 0.3 galaxies) in the sweep catalogs.
 
 ================= ========== ==========================================================================
 Name              Type       Description
@@ -730,14 +730,12 @@ Name              Type       Description
 ``training``      boolean    whether or not the spectroscopic redshift is used in photometric redshift training
 ================= ========== ==========================================================================
 
-Work which uses this photometric redshift catalog should cite `Zhou et al. (2020)`_
-and include the following acknowledgment: "The Photometric Redshifts for the
-Legacy Surveys (PRLS) catalog used in this paper was produced thanks to
-funding from the U.S. Department of Energy Office of Science, Office of
-High Energy Physics via grant DE-SC0007914."
+Work which uses this photometric redshift catalog should cite `Zhou et al. (2021)`_
+and include the `additional acknowledgment for photometric redshifts`_.
 
-.. _`Zhou et al. (2020)`: https://arxiv.org/abs/2001.06018
-.. _`Zhou et al. 2020`: https://arxiv.org/abs/2001.06018
+.. _`additional acknowledgment for photometric redshifts`: ../../acknowledgment/#photometric-redshifts
+.. _`Zhou et al. (2021)`: https://ui.adsabs.harvard.edu/abs/2021MNRAS.501.3309Z/abstract
+.. _`Zhou et al. 2021`:	https://ui.adsabs.harvard.edu/abs/2021MNRAS.501.3309Z/abstract
 
 Image Stacks (``<region>/coadd/*``)
 ===================================

--- a/pages/dr9/description.rst
+++ b/pages/dr9/description.rst
@@ -179,42 +179,42 @@ to be multiplied by both gain and ``exptime`` to retrieve units of electrons (fo
 Sections of the Legacy Surveys for DR9 can be obtained as JPEGs or FITS files using
 the cutout service, for example, as follows:
 
-JPEG: https://www.legacysurvey.org/viewer/jpeg-cutout?ra=190.1086&dec=1.2005&layer=dr9&pixscale=0.27&bands=grz
+JPEG: https://www.legacysurvey.org/viewer/jpeg-cutout?ra=190.1086&dec=1.2005&layer=ls-dr9&pixscale=0.27&bands=grz
 
-FITS: https://www.legacysurvey.org/viewer/fits-cutout?ra=190.1086&dec=1.2005&layer=dr9&pixscale=0.27&bands=grz
+FITS: https://www.legacysurvey.org/viewer/fits-cutout?ra=190.1086&dec=1.2005&layer=ls-dr9&pixscale=0.27&bands=grz
 
 This will merge the northern (MzLS+BASS) and southern (DECam) images at a line corresponding to Dec=32.375\ |deg|.
 
 To request images from only the northern or southern surveys, specify `dr9-north` or `dr9-south`, for example:
 
-JPEG (`DECaLS`_): https://www.legacysurvey.org/viewer/jpeg-cutout?ra=190.1086&dec=1.2005&layer=dr9-south&pixscale=0.27&bands=grz
+JPEG (`DECaLS`_): https://www.legacysurvey.org/viewer/jpeg-cutout?ra=190.1086&dec=1.2005&layer=ls-dr9-south&pixscale=0.27&bands=grz
 
-FITS (`DECaLS`_): https://www.legacysurvey.org/viewer/fits-cutout?ra=190.1086&dec=1.2005&layer=dr9-south&pixscale=0.27&bands=grz
+FITS (`DECaLS`_): https://www.legacysurvey.org/viewer/fits-cutout?ra=190.1086&dec=1.2005&layer=ls-dr9-south&pixscale=0.27&bands=grz
 
-JPEG (`BASS`_/`MzLS`_): https://www.legacysurvey.org/viewer/jpeg-cutout?ra=154.7709&dec=46.4537&layer=dr9-north&pixscale=0.27&bands=grz
+JPEG (`BASS`_/`MzLS`_): https://www.legacysurvey.org/viewer/jpeg-cutout?ra=154.7709&dec=46.4537&layer=ls-dr9-north&pixscale=0.27&bands=grz
 
-FITS (`BASS`_/`MzLS`_): https://www.legacysurvey.org/viewer/fits-cutout?ra=154.7709&dec=46.4537&layer=dr9-north&pixscale=0.27&bands=grz
+FITS (`BASS`_/`MzLS`_): https://www.legacysurvey.org/viewer/fits-cutout?ra=154.7709&dec=46.4537&layer=ls-dr9-north&pixscale=0.27&bands=grz
 
 where "bands" is a string such as ":math:`grz`",":math:`gz`",":math:`g`", etc.
 
-Replacing `layer=dr9` (or `layer=dr9-north`) with `layer=dr9-model` (`layer=dr9-north-model`)
-or `layer=dr9-resid` (`layer=dr9-north-resid`) will instead return cutouts for the model and residual images, respectively.
+Replacing `layer=ls-dr9` (or, e.g., `layer=ls-dr9-north`) with `layer=ls-dr9-model` (`layer=ls-dr9-north-model`)
+or `layer=ls-dr9-resid` (`layer=ls-dr9-north-resid`) will instead return cutouts for the model and residual images, respectively.
 
 The size of the image can also be specified using :math:`width`, :math:`height` and :math:`size`,
 where :math:`size` forces :math:`width` and :math:`height` to be equal. For example:
 
-https://www.legacysurvey.org/viewer/jpeg-cutout?ra=190.1086&dec=1.2005&width=100&layer=dr9&pixscale=0.3&bands=grz
+https://www.legacysurvey.org/viewer/jpeg-cutout?ra=190.1086&dec=1.2005&width=100&layer=ls-dr9&pixscale=0.3&bands=grz
 
-https://www.legacysurvey.org/viewer/jpeg-cutout?ra=190.1086&dec=1.2005&height=100&layer=dr9&pixscale=0.3&bands=grz
+https://www.legacysurvey.org/viewer/jpeg-cutout?ra=190.1086&dec=1.2005&height=100&layer=ls-dr9&pixscale=0.3&bands=grz
 
-https://www.legacysurvey.org/viewer/jpeg-cutout?ra=190.1086&dec=1.2005&size=100&layer=dr9&pixscale=0.3&bands=grz
+https://www.legacysurvey.org/viewer/jpeg-cutout?ra=190.1086&dec=1.2005&size=100&layer=ls-dr9&pixscale=0.3&bands=grz
 
 It is possible to retrieve multiple cutouts from the command line using standard utilites such as `wget`_.
 
 The maximum size for cutouts (in number of pixels) is currently 512.
 Pixscale=0.262 will return (approximately) the native pixels used by the `Tractor`_.
 
-See also the `list of URL/cutout patterns that are supported by the viewer`_.
+More examples are available on the `list of URL/cutout patterns that are supported by the viewer`_.
 
 .. _`list of URL/cutout patterns that are supported by the viewer`: https://www.legacysurvey.org/viewer/urls
 .. _`wget`: https://www.gnu.org/software/wget/manual/wget.html#Overview

--- a/pages/dr9/external.rst
+++ b/pages/dr9/external.rst
@@ -40,25 +40,28 @@ External Catalogs used for Masking
 
 External catalogs are used for masking regions near foreground sources in DR9
 (e.g. to construct ``MASKBITS`` on the `bitmasks page`_).
-These catalogs are available to collaborators in the indicated directories at NERSC.
+These catalogs are available in the indicated directories at NERSC and at the listed urls.
 
 "BRIGHT" stars
 --------------
-| **/global/cfs/cdirs/cosmo/staging/tycho2** and
-| **/global/cfs/cdirs/cosmo/work/gaia/chunks-gaia-dr2-astrom-2**
-|     Bright stars are defined from a starting sample of all sources in the Tycho-2 catalog that have ``MAG_VT`` < 13.  The ``BRIGHT`` bit is set for all such Tycho-2 stars. In addition, Gaia DR2 sources with ``phot_g_mean_mag`` < 13 have the ``BRIGHT`` bit set, provided they do not already match a Tycho-2 source. Gaia and Tycho-2 sources are matched after accounting for proper motion.
+
+| **/global/cfs/cdirs/cosmo/data/legacysurvey/dr9/masking/gaia-mask-dr9.fits.gz**
+| https://portal.nersc.gov/cfs/cosmo/data/legacysurvey/dr9/masking/gaia-mask-dr9.fits.gz
+|     Bright stars are defined from a starting sample of all sources in the Tycho-2 catalog that have ``MAG_VT`` < 13.  The ``BRIGHT`` bit is set for all such Tycho-2 stars. In addition, Gaia DR2 sources with ``phot_g_mean_mag`` < 13 have the ``BRIGHT`` bit set, provided they do not already match a Tycho-2 source. Gaia and Tycho-2 sources are matched after accounting for proper motion. In the **gaia-mask-dr9.fits.gz** file, bright stars have the ``isbright`` column set to ``True``.
 
 "MEDIUM-bright" stars
 ---------------------
-| **/global/cfs/cdirs/cosmo/staging/tycho2** and
-| **/global/cfs/cdirs/cosmo/work/gaia/chunks-gaia-dr2-astrom-2**
-|     Medium-bright stars are also defined starting with all sources in the Tycho-2 catalog cut to ``MAG_VT`` < 13.  All such Tycho-2 stars have the ``MEDIUM`` bit set. In addition, Gaia DR2 sources with ``phot_g_mean_mag`` < 16 have the ``MEDIUM`` bit set, provided they do not already match a Tycho-2 source (where the match accounts for proper motion). Note that this means that all ``BRIGHT`` stars also have the ``MEDIUM`` bit set. The specific (Gaia G) magnitude-radius relationship is `hardcoded in legacypipe`_.
+
+| **/global/cfs/cdirs/cosmo/data/legacysurvey/dr9/masking/gaia-mask-dr9.fits.gz**
+| https://portal.nersc.gov/cfs/cosmo/data/legacysurvey/dr9/masking/gaia-mask-dr9.fits.gz
+|     Medium-bright stars are also defined starting with all sources in the Tycho-2 catalog cut to ``MAG_VT`` < 13.  All such Tycho-2 stars have the ``MEDIUM`` bit set. In addition, Gaia DR2 sources with ``phot_g_mean_mag`` < 16 have the ``MEDIUM`` bit set, provided they do not already match a Tycho-2 source (where the match accounts for proper motion). Note that this means that all ``BRIGHT`` stars also have the ``MEDIUM`` bit set. The specific (Gaia G) magnitude-radius relationship is `hardcoded in legacypipe`_. In the **gaia-mask-dr9.fits.gz** file, medium-bright stars have the ``ismedium`` column	set to ``True``.
 
 
 Globular Clusters & Planetary Nebulae
 -------------------------------------
 
 | **/global/cfs/cdirs/cosmo/data/legacysurvey/dr9/masking/NGC-star-clusters.fits**
+| https://portal.nersc.gov/cfs/cosmo/data/legacysurvey/dr9/masking/NGC-star-clusters.fits
 |     In DR9, we treat globular clusters and planetary nebulae by turning off source detection (although we do perform forced photometry of Gaia sources) and using the ``CLUSTER`` bit to identify the regions of the sky occupied by these systems. We construct our catalog using the following procedure:
 
 1. First, we select all objects classified as ``GCl`` or ``PN`` from the
@@ -88,7 +91,9 @@ publicly-accessible directory given above. Objects in this mask are given the
 Large Galaxies
 --------------
 | **/global/cfs/cdirs/cosmo/data/legacysurvey/dr9/masking/SGA-parent-v3.0.kd.fits** and 
-| **/global/cfs/cdirs/cosmo/data/legacysurvey/dr9/masking/SGA-ellipse-v3.0.kd.fits** 
+| **/global/cfs/cdirs/cosmo/data/legacysurvey/dr9/masking/SGA-ellipse-v3.0.kd.fits**
+| https://portal.nersc.gov/cfs/cosmo/data/legacysurvey/dr9/masking/SGA-parent-v3.0.kd.fits and
+| https://portal.nersc.gov/cfs/cosmo/data/legacysurvey/dr9/masking/SGA-ellipse-v3.0.kd.fits
 |     These catalogs are based on the 2020 version of the Siena Galaxy Atlas, `SGA-2020`_. The elliptical geometry listed in the *parent* catalog was used to mask large galaxies during sky-subtraction, while the elliptical geometry in the *ellipse* catalog determined where we set the ``GALAXY`` ``MASKBITS`` bit (see the `bitmasks page`_). Specifically, we use the ``RA``, ``DEC``, ``DIAM``, ``PA``, and ``BA`` parameters in these catalogs, as documented in the `SGA-2020.fits`_ data model. 
 
 .. _`bitmasks page`: ../bitmasks
@@ -99,7 +104,7 @@ Large Galaxies
 .. _`star-clusters-supplemental.csv`: https://github.com/legacysurvey/legacypipe/blob/DR9.6.0/py/legacypipe/data/star-clusters-supplemental.csv
 .. _`OpenNGC`: https://github.com/mattiaverga/OpenNGC
 .. _`SGA-2020`: ../../sga/sga2020
-.. _`SGA-2020.fits`: ../../sga/sga2020#sga-2020.fits
+.. _`SGA-2020.fits`: ../../sga/sga2020#sga-2020-fits
 .. _`DECaLS`: ../../decamls
 .. _`Fornax`: https://www.legacysurvey.org/viewer?ra=39.997&dec=-34.449&layer=ls-dr9&zoom=10&GCs-PNe
 .. _`Sculptor`: https://www.legacysurvey.org/viewer?ra=15.039&dec=-33.709&layer=ls-dr9&zoom=10&GCs-PNe

--- a/pages/dr9/files.rst
+++ b/pages/dr9/files.rst
@@ -854,14 +854,23 @@ and include the `additional acknowledgment for photometric redshifts`_.
 .. _`Zhou et al. (2021)`: https://ui.adsabs.harvard.edu/abs/2021MNRAS.501.3309Z/abstract
 .. _`Zhou et al. 2021`: https://ui.adsabs.harvard.edu/abs/2021MNRAS.501.3309Z/abstract
 
-Coming Soon! - Star masks (``masks/*``)
+Foreground object masks (``masking/*``)
 =======================================
 
-gaia-mask-dr9-fixed.fits
-------------------------
+The foreground object masks were used to set the ``BRIGHT``, ``MEDIUM``, ``GALAXY`` and ``CLUSTER`` bits
+described on the `DR9 bitmasks page`_. Files in the ``masking`` directory other than **gaia-mask-dr9.fits.gz**
+are generally described as part the overview of the `external catalogs used for masking`_, and have data models
+that are detailed as part of the `Siena Galaxy Atlas (SGA)`_.
+
+gaia-mask-dr9.fits.gz
+---------------------
 
 A FITS binary table with a single HDU containing information about the `Tycho-2`_ and `Gaia`_ DR2 stars used to
-set the ``BRIGHT`` and ``MEDIUM`` bits described on the `DR9 bitmasks page`_.
+set the ``BRIGHT`` and ``MEDIUM`` bits described on the `DR9 bitmasks page`_. See also the general overview of
+the `external catalogs used for masking`_.
+
+.. _`external catalogs used for masking`: ../external/#external-catalogs-used-for-masking
+.. _`Siena Galaxy Atlas (SGA)`: ../../sga
 
 ===================================== ======= ================== ========================
 Name                                  Type    Units              Description

--- a/pages/dr9/files.rst
+++ b/pages/dr9/files.rst
@@ -805,15 +805,15 @@ in each row of the standard sweeps files, which can be verified using ``RELEASE`
 ``BRICKID`` and ``OBJID``).
 
 
-Coming Soon! - Photometric Redshift sweeps
-------------------------------------------
+Photometric Redshift sweeps
+---------------------------
 .. (9.0-photo-z/sweep-<brickmin>-<brickmax>-pz.fits)
 
-The Photometric Redshifts for the Legacy Surveys (PRLS, `Zhou et al. 2020`_)
-catalog is line-matched to the DR9 sweep catalogs as described above.
+The Photometric Redshifts for the Legacy Surveys (PRLS, e.g., see `Zhou et al. 2021`_)
+catalog is row-by-row-matched to the DR9 sweep catalogs as described previously for the other types of sweeps files.
 
 The photometric redshifts are computed using the random forest algorithm.
-Details of the photo-z training and performance can be found in `Zhou et al. (2020)`_.
+Details of the photo-z training and performance can be found in `Zhou et al. (2021)`_.
 For computing the photo-z's, we require at least one exposure in
 :math:`g`, :math:`r` and :math:`z` bands (``NOBS_G,R,Z>1``).
 For objects that do not meet the NOBS cut,
@@ -827,31 +827,32 @@ The photo-z catalogs do not provide information on star-galaxy separation.
 Stars are excluded from the photo-z training data, and we do not attempt to
 identify stars. To perform star-galaxy separation, one can use the
 morphological "TYPE" and/or the photometry (*e.g.*, the optical-WISE
-color cut, as applied in  `Zhou et al. 2020`_, can be very effective for selecting redshift |gtapprox| 0.3 galaxies) in the sweep catalogs.
+color cut, as applied in  `Zhou et al. 2021`_, can be very effective for selecting redshift |gtapprox| 0.3 galaxies) in the sweep catalogs.
 
 ================= ========== ==========================================================================
 Name              Type       Description
 ================= ========== ==========================================================================
-``z_phot_mean``   float32    photo-z derived from the mean of the photo-z PDF
-``z_phot_median`` float32    photo-z derived from the median of the photo-z PDF
-``z_phot_std``    float32    standard deviation of the photo-z's derived from the photo-z PDF
-``z_phot_l68``    float32    lower bound of the 68% confidence region, derived from the photo-z PDF
-``z_phot_u68``    float32    upper bound of the 68% confidence region, derived from the photo-z PDF
-``z_phot_l95``    float32    lower bound of the 95% confidence region, derived from the photo-z PDF
-``z_phot_u95``    float32    upper bound of the 68% confidence region, derived from the photo-z PDF
-``z_spec``        float32    spectroscopic redshift, if available
-``survey``        char[10]   source of the spectroscopic redshift
-``training``      boolean    whether or not the spectroscopic redshift is used in photometric redshift training
+``RELEASE``	  int16      Integer denoting the camera and filter set used, which will be unique for a given processing run of the data (`RELEASE is documented here`_)
+``BRICKID``       int32      A unique Brick ID (in the range [1, 662174])
+``OBJID``         int32      Catalog object number within this brick; a unique identifier hash is ``RELEASE,BRICKID,OBJID``; ``OBJID`` spans [0,N-1] and is contiguously enumerated within each blob
+``Z_PHOT_MEAN``   float32    photo-z derived from the mean of the photo-z PDF
+``Z_PHOT_MEDIAN`` float32    photo-z derived from the median of the photo-z PDF
+``Z_PHOT_STD``    float32    standard deviation of the photo-z's derived from the photo-z PDF
+``Z_PHOT_L68``    float32    lower bound of the 68% confidence region, derived from the photo-z PDF
+``Z_PHOT_U68``    float32    upper bound of the 68% confidence region, derived from the photo-z PDF
+``Z_PHOT_L95``    float32    lower bound of the 95% confidence region, derived from the photo-z PDF
+``Z_PHOT_U95``    float32    upper bound of the 68% confidence region, derived from the photo-z PDF
+``Z_SPEC``        float32    spectroscopic redshift, if available
+``SURVEY``        char[10]   source of the spectroscopic redshift
+``TRAINING``      boolean    whether or not the spectroscopic redshift is used in photometric redshift training
 ================= ========== ==========================================================================
 
-Work which uses this photometric redshift catalog should cite `Zhou et al. (2020)`_
-and include the following acknowledgment: "The Photometric Redshifts for the
-Legacy Surveys (PRLS) catalog used in this paper was produced thanks to
-funding from the U.S. Department of Energy Office of Science, Office of
-High Energy Physics via grant DE-SC0007914."
+Work which uses this photometric redshift catalog should cite `Zhou et al. (2021)`_
+and include the `additional acknowledgment for photometric redshifts`_.
 
-.. _`Zhou et al. (2020)`: https://arxiv.org/abs/2001.06018
-.. _`Zhou et al. 2020`: https://arxiv.org/abs/2001.06018
+.. _`additional acknowledgment for photometric redshifts`: ../../acknowledgment/#photometric-redshifts
+.. _`Zhou et al. (2021)`: https://ui.adsabs.harvard.edu/abs/2021MNRAS.501.3309Z/abstract
+.. _`Zhou et al. 2021`: https://ui.adsabs.harvard.edu/abs/2021MNRAS.501.3309Z/abstract
 
 Coming Soon! - Star masks (``masks/*``)
 =======================================

--- a/pages/index.rst
+++ b/pages/index.rst
@@ -53,7 +53,7 @@
 
    .. raw:: html
 
-      <h2>Acknowledgements</h2> <h3>(see also the <a href="acknowledgment">formal acknowledgment for publications</a>)</h3>
+      <h2>Acknowledgments</h2> <h3>(see also the <a href="acknowledgment">formal acknowledgment for publications</a>)</h3>
 
 
    *The LBNL Physics Division is supported by the U.S. Department of


### PR DESCRIPTION
This PR adds some quick but needed fixes and updates for the DR9 pages:
- Remove the "Coming Soon" language for the `photo-z` files and `masking` directory, now that we've made those public.
- Fix some broken links for the cutout server.
- Add some BASS collaborators that were missing on the `Contacts` page.

I'm going to leave this as WIP for now, but I thought I'd push these updates in case we decide we want to serve a new version of the website sooner rather than later.