### PR TITLE
fix incorrect links to the SGA

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## 9.0.3 (DR9, unreleased)
 
+- Fix incorrect/broken links to the SGA documentation
+  ([PR#145](https://github.com/legacysurvey/legacysurvey/pull/145)).
 - Automate removal of outdated JavaScript files
   ([PR#144](https://github.com/legacysurvey/legacysurvey/pull/144)).
 

--- a/pages/acknowledgment.rst
+++ b/pages/acknowledgment.rst
@@ -127,4 +127,4 @@ U.S. Department of Energy, Office of Science, Office of High Energy Physics
 under Award Number DE-SC0020086 and from the National Science Foundation under
 grant AST-1616414.
 
-.. _`Siena Galaxy Atlas`: ../sga
+.. _`Siena Galaxy Atlas`: ../../sga/sga2020

--- a/pages/contact.rst
+++ b/pages/contact.rst
@@ -82,7 +82,7 @@ Pan-STARRS1 Catalogs:
     * Doug Finkbeiner  dfinkbeiner@cfa.harvard.edu
 
 .. _`Legacypipe`: https://legacypipe.readthedocs.io/en/latest/
-.. _`Siena Galaxy Atlas`: ../sga
+.. _`Siena Galaxy Atlas`: ../../sga/sga2020
 
 Additional contributors
 -----------------------

--- a/pages/dr9/bitmasks.rst
+++ b/pages/dr9/bitmasks.rst
@@ -40,7 +40,7 @@ Bit Name          Description
 .. _`G < 13`: https://github.com/legacysurvey/legacypipe/blob/6d1a92f8462f4db9360fb1a68ef7d6c252781027/py/legacypipe/reference.py#L310
 .. _`G < 16`: https://github.com/legacysurvey/legacypipe/blob/6d1a92f8462f4db9360fb1a68ef7d6c252781027/py/legacypipe/reference.py#L311
 .. _`Gaia`: https://gea.esac.esa.int/archive/documentation//GDR2/Gaia_archive/chap_datamodel/sec_dm_main_tables/ssec_dm_gaia_source.html
-.. _`SGA`: ../sga
+.. _`SGA`: ../../sga/sga2020
 .. _`half of`: https://github.com/legacysurvey/legacypipe/blob/6d1a92f8462f4db9360fb1a68ef7d6c252781027/py/legacypipe/reference.py#L672-L675
 
 ``FITBITS``

--- a/pages/dr9/catalogs.rst
+++ b/pages/dr9/catalogs.rst
@@ -29,7 +29,7 @@ such quantities are often quoted on the Vega system).
 .. _`DECaLS`: ../../decamls
 .. _`MzLS`: ../../mzls
 .. _`DR9 bitmasks page`: ../bitmasks
-.. _`SGA`: ../sga
+.. _`SGA`: ../../sga/sga2020
 
 ===================================== ============ ===================== ===============================================
 Name                                  Type         Units                 Description

--- a/pages/dr9/description.rst
+++ b/pages/dr9/description.rst
@@ -300,9 +300,9 @@ using `polynomial fits to Gaia-to-DECam`_ color transformations for stars.
 Transformations to `DECam`_ are used even in areas of the Legacy Surveys footprint that are only covered by `BASS`_ and `MzLS`_.
 The ``flux_ivar_[grz]`` values for these "retained" Gaia sources are set to zero.
 
-.. _`SGA (Siena Galaxy Atlas)`: ../sga
-.. _`SGA`: ../sga
-.. _`Siena Galaxy Atlas`: ../sga
+.. _`SGA (Siena Galaxy Atlas)`: ../../sga/sga2020
+.. _`SGA`: ../../sga/sga2020
+.. _`Siena Galaxy Atlas`: ../../sga/sga2020
 .. _`bitmasks page`: ../bitmasks
 .. _`MEDIUM is set but BRIGHT, CLUSTER, and GALAXY are not`: ../bitmasks
 .. _`external catalogs page`: ../external

--- a/pages/dr9/external.rst
+++ b/pages/dr9/external.rst
@@ -60,7 +60,6 @@ These catalogs are available in the indicated directories at NERSC and at the li
 .. _`to G < 13`: https://github.com/legacysurvey/legacypipe/blob/6d1a92f8462f4db9360fb1a68ef7d6c252781027/py/legacypipe/reference.py#L310
 .. _`G < 16`: https://github.com/legacysurvey/legacypipe/blob/6d1a92f8462f4db9360fb1a68ef7d6c252781027/py/legacypipe/reference.py#L311
 .. _`Gaia`: https://gea.esac.esa.int/archive/documentation//GDR2/Gaia_archive/chap_datamodel/sec_dm_main_tables/ssec_dm_gaia_source.html
-.. _`SGA`: ../sga
 .. _`half of`: https://github.com/legacysurvey/legacypipe/blob/6d1a92f8462f4db9360fb1a68ef7d6c252781027/py/legacypipe/reference.py#L672-L675
 
 

--- a/pages/dr9/files.rst
+++ b/pages/dr9/files.rst
@@ -757,7 +757,7 @@ Name                                  Type         Units                 Descrip
 
 .. _`Gaia`: https://gea.esac.esa.int/archive/documentation//GDR2/Gaia_archive/chap_datamodel/sec_dm_main_tables/ssec_dm_gaia_source.html
 .. _`Tycho-2`: https://heasarc.gsfc.nasa.gov/W3Browse/all/tycho2.html
-.. _`SGA`: ../sga
+.. _`SGA`: ../../sga/sga2020
 
 .. _photometric-redshifts:
 
@@ -872,7 +872,7 @@ set the ``BRIGHT`` and ``MEDIUM`` bits described on the `DR9 bitmasks page`_. Se
 the `external catalogs used for masking`_.
 
 .. _`external catalogs used for masking`: ../external/#external-catalogs-used-for-masking
-.. _`Siena Galaxy Atlas (SGA)`: ../../sga
+.. _`Siena Galaxy Atlas (SGA)`: ../../sga/sga2020
 
 ===================================== ======= ================== ========================
 Name                                  Type    Units              Description

--- a/pages/dr9/updates.rst
+++ b/pages/dr9/updates.rst
@@ -177,7 +177,7 @@ Data model changes
 .. _`light curve sweep files`: ../files/#light-curve-sweeps-9-0-lightcurves-sweep-brickmin-brickmax-lc-fits
 .. _`extra sweep files`: ../files/#extra-sweeps-9-0-lightcurves-sweep-brickmin-brickmax-ex-fits
 .. _`region-specific survey bricks files`: ../files/#region-survey-bricks-dr9-region-fits-gz
-.. _`SGA`: ../sga
+.. _`SGA`: ../../sga/sga2020
 .. _`files of data from fitting in SGA regions`: ../files/#large-galaxy-files-largegalaxies-aaa-galname
 .. _`coadds`: ../files/#image-stacks-region-coadd
 .. _`external match files`: ../files/#external-match-files-region-external


### PR DESCRIPTION
I neglected to update all the links to the updated SGA documentation in my previous PRs.