### PR TITLE
[WIP] Remove noao.edu URLs

### DIFF
--- a/.github/workflows/nikola-package.yml
+++ b/.github/workflows/nikola-package.yml
@@ -32,7 +32,7 @@ jobs:
             - name: Install Python dependencies
               run: |
                   python -m pip install --upgrade pip wheel
-                  python -m pip install nikola==${{ matrix.nikola-version }}
+                  python -m pip install nikola==${{ matrix.nikola-version }} docutils==0.16
             - name: Run the test
               run: |
                   nikola build --strict
@@ -45,8 +45,7 @@ jobs:
           fail-fast: false
           matrix:
                 os: [ubuntu-latest]
-                python-version: [3.8]
-                nikola-version: ['8.0.3']
+                python-version: [3.9]
 
       steps:
             - name: Checkout code
@@ -60,7 +59,7 @@ jobs:
             - name: Install Python dependencies
               run: |
                   python -m pip install --upgrade pip wheel
-                  python -m pip install nikola==${{ matrix.nikola-version }}
+                  python -m pip install nikola
             - name: Run the test; failures are allowed
               continue-on-error: true
               run: |

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,7 @@
 
 ## 9.0.6 (DR9, unreleased)
 
-- No changes yet.
+- Replace `noao.edu` with `noirlab.edu` wherever possible ([PR#150](https://github.com/legacysurvey/legacysurvey/pull/150)).
 
 ## 9.0.5 (DR9, 2022-01-27)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,9 @@
 
 ## 9.0.6 (DR9, unreleased)
 
-- Replace `noao.edu` with `noirlab.edu` wherever possible ([PR#150](https://github.com/legacysurvey/legacysurvey/pull/150)).
+- Replace `noao.edu` with `noirlab.edu` wherever possible; move raw
+  data access instructions into a unified, top-level page
+  ([PR#150](https://github.com/legacysurvey/legacysurvey/pull/150)).
 
 ## 9.0.5 (DR9, 2022-01-27)
 

--- a/conf.py
+++ b/conf.py
@@ -100,6 +100,7 @@ NAVIGATION_LINKS = {
             ("https://www.darkenergysurvey.org", 'DES'),
             # ("http://batc.bao.ac.cn/BASS", 'BASS'),
             ("http://unwise.me", 'unWISE'),
+            ("/rawdata", 'Raw Data')
             ), 'Other Data'),
         ((
         ("https://www.legacysurvey.org/viewer", 'Go to the Sky Viewer'),

--- a/pages/acknowledgement-old.rst
+++ b/pages/acknowledgement-old.rst
@@ -1,25 +1,25 @@
 .. title: Acknowledgment for all Legacy Survey Data
 .. slug: acknowledgment-old
 .. tags: mathjax
-.. description: 
+.. description:
 
 When using data from the Legacy Surveys in papers, please use the following acknowledgment:
 
-This paper uses data that were obtained by The Legacy Surveys: the Dark Energy Camera Legacy Survey (DECaLS; NOAO Proposal ID # 2014B-0404; PIs: 
-David Schlegel and Arjun Dey), the Beijing-Arizona Sky Survey (BASS; NOAO Proposal ID # 2015A-0801; PIs: Zhou Xu and Xiaohui Fan), and the Mayall 
-z-band Legacy Survey (MzLS; NOAO Proposal ID # 2016A-0453; PI: Arjun Dey). DECaLS, BASS and MzLS together include data obtained, respectively, at 
-the Blanco telescope, Cerro Tololo Inter-American Observatory, National Optical Astronomy Observatory (NOAO); the Bok telescope, Steward 
-Observatory, University of Arizona; and the Mayall telescope, Kitt Peak National Observatory, NOAO. NOAO is operated by the Association of 
-Universities for Research in Astronomy (AURA) under a cooperative agreement with the National Science Foundation. Please see 
-http://legacysurvey.org for details regarding the Legacy Surveys. BASS is a key project of the Telescope Access Program (TAP), which has been 
-funded by the National Astronomical Observatories of China, the Chinese Academy of Sciences (the Strategic Priority Research Program "The 
-Emergence of Cosmological Structures" Grant No. XDB09000000), and the Special Fund for Astronomy from the Ministry of Finance. The BASS is 
-also supported by the External Cooperation Program of Chinese Academy of Sciences (Grant No. 114A11KYSB20160057) and Chinese National Natural 
-Science Foundation (Grant No. 11433005). The Legacy Surveys imaging of the DESI footprint is supported by the Director, Office of Science, 
-Office of High Energy Physics of the U.S. Department of Energy under Contract No. DE-AC02-05CH1123, and by the National Energy Research Scientific 
-Computing Center, a DOE Office of Science User Facility under the same contract; and by the U.S. National Science Foundation, Division of 
+This paper uses data that were obtained by The Legacy Surveys: the Dark Energy Camera Legacy Survey (DECaLS; NOAO Proposal ID # 2014B-0404; PIs:
+David Schlegel and Arjun Dey), the Beijing-Arizona Sky Survey (BASS; NOAO Proposal ID # 2015A-0801; PIs: Zhou Xu and Xiaohui Fan), and the Mayall
+z-band Legacy Survey (MzLS; NOAO Proposal ID # 2016A-0453; PI: Arjun Dey). DECaLS, BASS and MzLS together include data obtained, respectively, at
+the Blanco telescope, Cerro Tololo Inter-American Observatory, National Optical Astronomy Observatory (NOAO); the Bok telescope, Steward
+Observatory, University of Arizona; and the Mayall telescope, Kitt Peak National Observatory, NOAO. NOAO is operated by the Association of
+Universities for Research in Astronomy (AURA) under a cooperative agreement with the National Science Foundation. Please see
+http://legacysurvey.org for details regarding the Legacy Surveys. BASS is a key project of the Telescope Access Program (TAP), which has been
+funded by the National Astronomical Observatories of China, the Chinese Academy of Sciences (the Strategic Priority Research Program "The
+Emergence of Cosmological Structures" Grant No. XDB09000000), and the Special Fund for Astronomy from the Ministry of Finance. The BASS is
+also supported by the External Cooperation Program of Chinese Academy of Sciences (Grant No. 114A11KYSB20160057) and Chinese National Natural
+Science Foundation (Grant No. 11433005). The Legacy Surveys imaging of the DESI footprint is supported by the Director, Office of Science,
+Office of High Energy Physics of the U.S. Department of Energy under Contract No. DE-AC02-05CH1123, and by the National Energy Research Scientific
+Computing Center, a DOE Office of Science User Facility under the same contract; and by the U.S. National Science Foundation, Division of
 Astronomical Sciences under Contract No.AST-0950945 to the National Optical Astronomy Observatory.
 
 In addition, please see the `NOAO acknowledgment page`_.
 
-.. _`NOAO acknowledgment page`: https://www.noao.edu/noao/library/NOAO_Publications_Acknowledgments.html
+.. _`NOAO acknowledgment page`: https://legacy.noirlab.edu/noao/library/NOAO_Publications_Acknowledgments.html

--- a/pages/decamls.rst
+++ b/pages/decamls.rst
@@ -10,10 +10,10 @@
 
 The Dark Energy Camera (DECam) on the Blanco 4m telescope,
 located at the Cerro Tololo Inter-American Observatory, will provide the optical
-imaging for targeting for 2/3 of the Dark Energy Spectroscopic Instrument (`DESI`_) 
+imaging for targeting for 2/3 of the Dark Energy Spectroscopic Instrument (`DESI`_)
 footprint, covering both the North Galactic Cap region at Dec |leq| 32\ |deg|
 and the South Galactic Cap region at Dec |leq| 34\ |deg|.  Due to the
-combination of large field of view and high sensitivity from 400-1000 nm, 
+combination of large field of view and high sensitivity from 400-1000 nm,
 DECam is an efficient option for obtaining photometry in the
 :math:`g`, :math:`r`, and :math:`z` bands.
 
@@ -25,7 +25,7 @@ radius of 0.45 arcsec.  Because of the incomplete fill factor of DECam,
 a 3-pass observing strategy has been designed where these depths are
 met with 2 of the 3 exposures.  Accounting for weather loss,
 DECam is capable of imaging 9000 deg\ |sup2| of the `DESI`_
-footprint to this depth in 157 scheduled nights. 
+footprint to this depth in 157 scheduled nights.
 
 A public survey, "The DECam Legacy Survey of the SDSS Equatorial
 Sky" (PI: D. Schlegel and A. Dey), was
@@ -64,7 +64,7 @@ and the `DESI Legacy Imaging Surveys Overview Paper.`_
 .. _`DESI`: https://desi.lbl.gov
 .. _`DES`: https://www.darkenergysurvey.org
 .. _`DESI Legacy Imaging Surveys Overview Paper.`: https://ui.adsabs.harvard.edu/abs/2019AJ....157..168D/abstract
-.. _`2013A-0741`: https://www.noao.edu/perl/abstract?2013A-0741
-.. _`2014B-0404`: https://www.noao.edu/perl/abstract?2014B-0404
+.. _`2013A-0741`: https://legacy.noirlab.edu/perl/abstract?2013A-0741
+.. _`2014B-0404`: https://legacy.noirlab.edu/perl/abstract?2014B-0404
 .. _`full proposal text`: https://www.legacysurvey.org/files/LargeSurvey.pdf
 .. _`DECam Legacy Survey Principles`: https://desi.lbl.gov/trac/wiki/PublicPages/DecamLegacy/Principles

--- a/pages/dr1/catalogs.rst
+++ b/pages/dr1/catalogs.rst
@@ -75,14 +75,14 @@ from the CP Data Quality bits.
 === ===== =========================== ==================================================
 Bit Value Name                        Description
 === ===== =========================== ==================================================
-  0     1 detector bad pixel/no data  detailed at http://www.noao.edu/noao/staff/fvaldes/CPDocPrelim/PL201_3.html
-  1     2 saturated                   detailed at http://www.noao.edu/noao/staff/fvaldes/CPDocPrelim/PL201_3.html
-  2     4 interpolated                detailed at http://www.noao.edu/noao/staff/fvaldes/CPDocPrelim/PL201_3.html
-  4    16 single exposure cosmic ray  detailed at http://www.noao.edu/noao/staff/fvaldes/CPDocPrelim/PL201_3.html
-  6    64 bleed trail                 detailed at http://www.noao.edu/noao/staff/fvaldes/CPDocPrelim/PL201_3.html
-  7   128 multi-exposure transient    detailed at http://www.noao.edu/noao/staff/fvaldes/CPDocPrelim/PL201_3.html
-  8   256 edge                        detailed at http://www.noao.edu/noao/staff/fvaldes/CPDocPrelim/PL201_3.html
-  9   512 edge2                       detailed at http://www.noao.edu/noao/staff/fvaldes/CPDocPrelim/PL201_3.html
+  0     1 detector bad pixel/no data  detailed at https://legacy.noirlab.edu/noao/staff/fvaldes/CPDocPrelim/PL201_3.html
+  1     2 saturated                   detailed at https://legacy.noirlab.edu/noao/staff/fvaldes/CPDocPrelim/PL201_3.html
+  2     4 interpolated                detailed at https://legacy.noirlab.edu/noao/staff/fvaldes/CPDocPrelim/PL201_3.html
+  4    16 single exposure cosmic ray  detailed at https://legacy.noirlab.edu/noao/staff/fvaldes/CPDocPrelim/PL201_3.html
+  6    64 bleed trail                 detailed at https://legacy.noirlab.edu/noao/staff/fvaldes/CPDocPrelim/PL201_3.html
+  7   128 multi-exposure transient    detailed at https://legacy.noirlab.edu/noao/staff/fvaldes/CPDocPrelim/PL201_3.html
+  8   256 edge                        detailed at https://legacy.noirlab.edu/noao/staff/fvaldes/CPDocPrelim/PL201_3.html
+  9   512 edge2                       detailed at https://legacy.noirlab.edu/noao/staff/fvaldes/CPDocPrelim/PL201_3.html
 === ===== =========================== ==================================================
 
 

--- a/pages/dr1/catalogs.rst
+++ b/pages/dr1/catalogs.rst
@@ -129,8 +129,10 @@ which are different from those used in SDSS-I,II,III, but are the values used fo
 
 Extinction coefficients for the DECam filters also use the Schlafly & Finkbeiner 2011 values,
 with u-band computed using the same formulae and code at airmass 1.3 (Schlafly, priv. comm. decam-data list on 11/13/14).
-These coefficients are A / E(B-V) = 3.995, 3.214, 2.165, 1.592, 1.211, 1.064.
-(These are slightly different than the ones in Schlafly & Finkbeiner (http://arxiv.org/abs/1012.4804).)
+These coefficients are :math:`A / E(B-V)` = 3.995, 3.214, 2.165, 1.592, 1.211, 1.064
+for the DECam :math:`u`, :math:`g`, :math:`r`, :math:`i`, :math:`z`, :math:`Y` filters,
+respectively.
+These are *slightly* different than the ones in Schlafly & Finkbeiner (http://arxiv.org/abs/1012.4804).
 
 The coefficients for the four WISE filters are derived from Fitzpatrick 1999, as recommended by Schafly & Finkbeiner,
 considered better than either the Cardelli et al 1989 curves or the newer Fitzpatrick & Massa 2009 NIR curve not vetted beyond 2 micron).

--- a/pages/dr1/description.rst
+++ b/pages/dr1/description.rst
@@ -27,9 +27,9 @@ the Blanco Telescope.
 
 Data Release 1 (DR1) is the first public data release of images and catalogs for
 the DECam Legacy Survey.  It includes DECam data primarily from z-band
-observations in August 2013 (http://www.noao.edu/perl/abstract?2013A-0741) and
+observations in August 2013 (https://legacy.noirlab.edu/perl/abstract?2013A-0741) and
 g,r,z-band observations from August 2014 through January 2015 for an NOAO survey
-program (https://www.noao.edu/perl/abstract?2014B-0404).  It also includes
+program (https://legacy.noirlab.edu/perl/abstract?2014B-0404).  It also includes
 public data from other programs near the Fall celestial equator bounded by 315 <
 |alpha| < 360 |deg| or 0 < |alpha| < 5 |deg|, and by -3\ |deg| < |delta| < +3\
 |deg|.  In total, the optical data covers a disjoint 3100 deg\ |sup2| footprint,
@@ -97,7 +97,7 @@ Sky Level
 
 The Community Pipeline removes a sky level that includes a sky pattern, an illumination correction,
 and a single scaled fringe pattern.  These steps are described here:
-http://www.noao.edu/noao/staff/fvaldes/CPDocPrelim/PL201_3.html .
+https://legacy.noirlab.edu/noao/staff/fvaldes/CPDocPrelim/PL201_3.html .
 This makes the sky level in the processed images near zero, and removes most pattern artifacts.
 A constant sky level is then added back to the image that is mean of what was removed.
 
@@ -306,7 +306,7 @@ Brick
 
 CP
     Community Pipeline (DECam reduction pipeline operated by NOAO;
-    http://www.noao.edu/noao/staff/fvaldes/CPDocPrelim/PL201_3.html).
+    https://legacy.noirlab.edu/noao/staff/fvaldes/CPDocPrelim/PL201_3.html).
 
 DECaLS
     `Dark Energy Camera Legacy Survey <http://legacysurvey.org>`_.
@@ -325,7 +325,7 @@ MoG
     Mixture-of-gaussian model to approximate the PSF and galaxy models (http://arxiv.org/abs/1210.6563).
 
 NOAO
-    `National Optical Astronomy Observatory <http://www.noao.edu>`_.
+    `National Optical Astronomy Observatory <https://legacy.noirlab.edu>`_.
 
 nanomaggie
     Linear flux units, where an object with an AB magnitude of 22.5 has a flux

--- a/pages/dr1/files.rst
+++ b/pages/dr1/files.rst
@@ -168,7 +168,7 @@ Column                     Type         Description
 
 ZeroPoints-DR1.fits
 -------------------
-The ZeroPoints-DR1.fits file contains information regarding the photometric and astrometric zero points for each CCD of every DECam image that is part of the DECaLS DR1 data release. Photometric zero points for each CCD are computed by identifying stars and comparing their instrumental magnitudes (measured in an approximately 7 arcsec diameter aperture) to color-selected stars in the PanSTARRS "qy" catalog. 
+The ZeroPoints-DR1.fits file contains information regarding the photometric and astrometric zero points for each CCD of every DECam image that is part of the DECaLS DR1 data release. Photometric zero points for each CCD are computed by identifying stars and comparing their instrumental magnitudes (measured in an approximately 7 arcsec diameter aperture) to color-selected stars in the PanSTARRS "qy" catalog.
 
 - HDU1 (only HDU) - tags in the ``ZeroPoints-DR1.fits`` file
 
@@ -289,22 +289,6 @@ the colors.
 Raw Data
 ========
 
-Raw Legacy Survey images are available through the NOAO Science Archive.  The
-*input* data used to create the stacked images, Tractor catalogs, etc. comprises
-images taken by the dedicated DECam Legacy Survey project, as well as other
-DECam images, and images from other surveys.  These instructions are for
-obtaining raw images from the DECam Legacy Survey *only*.
+See the `raw data page`_.
 
-1. Visit the `NOAO Science Archive`_.
-2. Click on `General Search for NOAO data (all users)`_.
-3. In the Simple Query Form, enter "2014B-0404" in the Program number box.
-4. Check "Raw" under All instruments.
-5. Click Search
-6. Once the query finishes, you can "Categorize by"  "Observation type".  The "object"
-   images are actual on-sky data.  Other Observation types are flats, darks, etc.
-7. The Results page offers several different ways to download the detail.  See
-   `the Tutorials page`_ for details.
-
-.. _`NOAO Science Archive`: http://portal-nvo.noao.edu
-.. _`General Search for NOAO data (all users)`: http://portal-nvo.noao.edu/search/query
-.. _`the Tutorials page`: http://portal-nvo.noao.edu/tutorials/query
+.. _`raw data page`: ../../rawdata

--- a/pages/dr2/catalogs.rst
+++ b/pages/dr2/catalogs.rst
@@ -12,7 +12,7 @@
 tractor/<AAA>/tractor-<brick>.fits
 ----------------------------------
 
-FITS binary table containing Tractor photometry. Note there is a 
+FITS binary table containing Tractor photometry. Note there is a
 `known issue`_ regarding the fact that some bricks contain pixels but zero sources, hence have empty (zero-row) catalog files.
 
 .. _`known issue`: ../issues
@@ -87,14 +87,14 @@ from the CP Data Quality bits.
 === ===== =========================== ==================================================
 Bit Value Name                        Description
 === ===== =========================== ==================================================
-  0     1 detector bad pixel/no data  detailed at https://www.noao.edu/noao/staff/fvaldes/CPDocPrelim/PL201_3.html
-  1     2 saturated                   detailed at https://www.noao.edu/noao/staff/fvaldes/CPDocPrelim/PL201_3.html
-  2     4 interpolated                detailed at https://www.noao.edu/noao/staff/fvaldes/CPDocPrelim/PL201_3.html
-  4    16 single exposure cosmic ray  detailed at https://www.noao.edu/noao/staff/fvaldes/CPDocPrelim/PL201_3.html
-  6    64 bleed trail                 detailed at https://www.noao.edu/noao/staff/fvaldes/CPDocPrelim/PL201_3.html
-  7   128 multi-exposure transient    detailed at https://www.noao.edu/noao/staff/fvaldes/CPDocPrelim/PL201_3.html
-  8   256 edge                        detailed at https://www.noao.edu/noao/staff/fvaldes/CPDocPrelim/PL201_3.html
-  9   512 edge2                       detailed at https://www.noao.edu/noao/staff/fvaldes/CPDocPrelim/PL201_3.html
+  0     1 detector bad pixel/no data  detailed at https://legacy.noirlab.edu/noao/staff/fvaldes/CPDocPrelim/PL201_3.html
+  1     2 saturated                   detailed at https://legacy.noirlab.edu/noao/staff/fvaldes/CPDocPrelim/PL201_3.html
+  2     4 interpolated                detailed at https://legacy.noirlab.edu/noao/staff/fvaldes/CPDocPrelim/PL201_3.html
+  4    16 single exposure cosmic ray  detailed at https://legacy.noirlab.edu/noao/staff/fvaldes/CPDocPrelim/PL201_3.html
+  6    64 bleed trail                 detailed at https://legacy.noirlab.edu/noao/staff/fvaldes/CPDocPrelim/PL201_3.html
+  7   128 multi-exposure transient    detailed at https://legacy.noirlab.edu/noao/staff/fvaldes/CPDocPrelim/PL201_3.html
+  8   256 edge                        detailed at https://legacy.noirlab.edu/noao/staff/fvaldes/CPDocPrelim/PL201_3.html
+  9   512 edge2                       detailed at https://legacy.noirlab.edu/noao/staff/fvaldes/CPDocPrelim/PL201_3.html
  10  1024 longthin                    :math:`\gt 5\sigma` connected components with major axis :math:`\gt 200` pixels and major/minor axis :math:`\gt 0.1`.  To mask, e.g, satellite trails.
 === ===== =========================== ==================================================
 
@@ -104,7 +104,7 @@ Goodness-of-Fits
 
 The DCHISQ values represent the |chi|\ |sup2| sum of all pixels in the source's blob
 for various models.  This 5-element vector contains the |chi|\ |sup2| difference between
-the best-fit point source (type="PSF"), simple galaxy model ("SIMP"), de Vaucouleurs model ("DEV"), 
+the best-fit point source (type="PSF"), simple galaxy model ("SIMP"), de Vaucouleurs model ("DEV"),
 exponential model ("EXP"), and a composite model ("COMP"), in that order.
 The "simple galaxy" model is an exponential galaxy with fixed shape of 0.45" and zero ellipticity (round)
 and is meant to capture slightly-extended but low signal-to-noise objects.

--- a/pages/dr2/catalogs.rst
+++ b/pages/dr2/catalogs.rst
@@ -139,8 +139,9 @@ which are different from those used in SDSS-I,II,III, but are the values used fo
 
 Extinction coefficients for the DECam filters also use the `Schlafly & Finkbeiner (2011)`_ values,
 with u-band computed using the same formulae and code at airmass 1.3 (Schlafly, priv. comm. decam-data list on 11/13/14).
-These coefficients are A / E(B-V) = 3.995, 3.214, 2.165, 1.592, 1.211, 1.064.
-(These are slightly different than the ones in `Schlafly & Finkbeiner 2011`_.)
+These coefficients are :math:`A / E(B-V)` = 3.995, 3.214, 2.165, 1.592, 1.211, 1.064
+for the DECam :math:`u`, :math:`g`, :math:`r`, :math:`i`, :math:`z`, :math:`Y` filters,
+respectively. Note that these are *slightly* different from the coefficients in `Schlafly & Finkbeiner (2011)`_.
 
 The coefficients for the four WISE filters are derived from Fitzpatrick 1999, as recommended by Schafly & Finkbeiner,
 considered better than either the Cardelli et al 1989 curves or the newer Fitzpatrick & Massa 2009 NIR curve not vetted beyond 2 micron).

--- a/pages/dr2/description.rst
+++ b/pages/dr2/description.rst
@@ -27,9 +27,9 @@ the Blanco Telescope.
 
 Data Release 2 (DR2) is the second public data release of images and catalogs for
 the DECam Legacy Survey. DR2 includes DECam data primarily from z-band
-observations in August 2013 (http://www.noao.edu/perl/abstract?2013A-0741) and
+observations in August 2013 (https://legacy.noirlab.edu/perl/abstract?2013A-0741) and
 g,r,z-band observations from August 2014 through June 2015 for an NOAO survey
-program (https://www.noao.edu/perl/abstract?2014B-0404).  It also includes
+program (https://legacy.noirlab.edu/perl/abstract?2014B-0404).  It also includes
 public data from other programs with the footprint, including data taken by the
 Dark Energy Survey that are now public, in the "stripe 82" region bounded by 315 <
 |alpha| < 360 |deg| or 0 < |alpha| < 5 |deg|, and by -3\ |deg| < |delta| < +3\
@@ -81,7 +81,7 @@ Obtaining Images and Raw Data
 ==============================
 
 Images can be viewed directly using `the Sky viewer`_
-and raw data can be obtained through `the NOAO portal`_ (see also the information near
+and raw data can be obtained through `the NOIRLab portal`_ (see also the information near
 the bottom of the `files`_ page).
 
 Sections of the Legacy Survey can be obtained as JPEGs or FITS files using
@@ -100,7 +100,7 @@ See also the `list of URL/cutout patterns that are supported by the viewer`_.
 .. _`list of URL/cutout patterns that are supported by the viewer`: https://www.legacysurvey.org/viewer/urls
 .. _`files`: ../files
 .. _`the Sky viewer`: https://www.legacysurvey.org/viewer
-.. _`the NOAO portal`: http://portal-nvo.noao.edu/
+.. _`the NOIRLab portal`: https://astroarchive.noirlab.edu/portal/search/
 
 Source Detection
 ================
@@ -134,7 +134,7 @@ Sky Level
 
 The Community Pipeline removes a sky level that includes a sky pattern, an illumination correction,
 and a single scaled fringe pattern.  These steps are described here:
-https://www.noao.edu/noao/staff/fvaldes/CPDocPrelim/PL201_3.html .
+https://legacy.noirlab.edu/noao/staff/fvaldes/CPDocPrelim/PL201_3.html .
 This makes the sky level in the processed images near zero, and removes most pattern artifacts.
 A constant sky level is then added back to the image that is the mean of what was removed.
 
@@ -248,7 +248,7 @@ The natural system means that we have not
 applied color terms to any of the photometry, but report fluxes as observed in the DECam filters.
 
 Zero point magnitudes for the CP version 2 reductions of the DECam images
-were computed by comparing 7\ |Prime| diameter aperture photometry to 
+were computed by comparing 7\ |Prime| diameter aperture photometry to
 PS1 photometry, where the latter was modified with color terms
 to place the PS1 photometry on the DECam system.  The same color terms
 are applied to all CCDs.
@@ -339,7 +339,7 @@ Brick
 
 CP
     Community Pipeline (DECam reduction pipeline operated by NOAO;
-    https://www.noao.edu/noao/staff/fvaldes/CPDocPrelim/PL201_3.html).
+    https://legacy.noirlab.edu/noao/staff/fvaldes/CPDocPrelim/PL201_3.html).
 
 DECaLS
     `Dark Energy Camera Legacy Survey <https://www.legacysurvey.org>`_.
@@ -359,7 +359,7 @@ MoG
     Mixture-of-gaussian model to approximate the galaxy models (https://arxiv.org/abs/1210.6563).
 
 NOAO
-    `National Optical Astronomy Observatory <http://www.noao.edu>`_.
+    `National Optical Astronomy Observatory <https://legacy.noirlab.edu>`_.
 
 nanomaggie
     Linear flux units, where an object with an AB magnitude of 22.5 has a flux

--- a/pages/dr2/files.rst
+++ b/pages/dr2/files.rst
@@ -438,23 +438,6 @@ the colors.
 Raw Data
 ========
 
+See the `raw data page`_.
 
-Raw Legacy Survey images are available through the NOIRLab Science Archive.  The
-*input* data used to create the stacked images, Tractor catalogs, etc. comprises
-images taken by the dedicated DECam Legacy Survey project, as well as other
-DECam images, and images from other surveys.  These instructions are for
-obtaining raw images from the DECam Legacy Survey *only*.
-
-
-1. Visit the `NOAO Science Archive`_.
-2. Click on `General Search for NOAO data (all users)`_.
-3. From the menu of "Available Collections" at left, select the desired DECaLS data release (e.g. DECaLS-DR2).
-4. Under "Data products - Raw data" check "Object".
-5. Optionally, you may select data from specific DECam filters, or restrict the search by other parameters such as sky coordinates, observing date, or exposure time.
-6. Click Search.
-7. The Results page offers several different ways to download the detail. See
-   `the Tutorials page`_ for details.
-
-.. _`NOAO Science Archive`: http://portal-nvo.noao.edu
-.. _`General Search for NOAO data (all users)`: http://portal-nvo.noao.edu/search/query
-.. _`the Tutorials page`: http://portal-nvo.noao.edu/tutorials/query
+.. _`raw data page`: ../../rawdata

--- a/pages/dr2/files.rst
+++ b/pages/dr2/files.rst
@@ -82,7 +82,7 @@ decals-ccds.fits.gz
 
 A FITS binary table with almanac information (e.g. seeing, etc.) about each individual CCD image. Note that this is the only file in the top-level directory that is gzipped (it is slightly larger than other such files and is gzipped for compliance with the legacysurvey github repository).
 
-This file contains information regarding the photometric and astrometric zero points for each CCD of every DECam image that is part of the DECaLS DR2 data release. Photometric zero points for each CCD are computed by identifying stars and comparing their instrumental magnitudes (measured in an approximately 7 arcsec diameter aperture) to color-selected stars in the PanSTARRS "qy" catalog. 
+This file contains information regarding the photometric and astrometric zero points for each CCD of every DECam image that is part of the DECaLS DR2 data release. Photometric zero points for each CCD are computed by identifying stars and comparing their instrumental magnitudes (measured in an approximately 7 arcsec diameter aperture) to color-selected stars in the PanSTARRS "qy" catalog.
 
 The photometric zeropoints (``zpt``, ``ccdzpt``, etc)
 are magnitude-like numbers (e.g. 25.04), and
@@ -101,7 +101,7 @@ Column             Type       Description
 ``filter``         char[1]    Filter used for observation, eg "g", "r", "z".
 ``seeing``         float      Seeing in arcseconds determined by fitting a 2-dimensional gaussian to the median PSF of stars on the CCD, eg 1.1019.
 ``date_obs``       char[10]   Date of observation start, eg "2014-08-15".  Can be combined with ``ut``, or use ``mjd_obs`` instead.
-``mjd_obs``        double     Date of observation in MJD (in UTC system), eg 56884.99373389.               
+``mjd_obs``        double     Date of observation in MJD (in UTC system), eg 56884.99373389.
 ``ut``             char[15]   Time of observation start, eg "23:50:58.608241".
 ``airmass``        float      Airmass, eg 1.35.
 ``propid``         char[10]   NOAO Proposal ID that took this image, eg "2014B-0404".
@@ -224,10 +224,10 @@ decals-dr2-specObj-dr12.fits
 ----------------------------
 HDU1 (the only HDU) contains Tractored DECaLS
 photometry that is row-by-row-matched to the SDSS DR12 spectrosopic
-pipeline file such that the photometric parameters in row "N" of 
+pipeline file such that the photometric parameters in row "N" of
 decals-dr2-specObj-dr12.fits matches the spectroscopic parameters in row "N" of
 specObj-dr12.fits. The structure of the DECaLS photometric catalog files is documented on the
-`catalogs page`_ and the spectroscopic file 
+`catalogs page`_ and the spectroscopic file
 is documented in the SDSS DR12 `data model for specObj-dr12.fits`_.
 
 .. _`catalogs page`: ../catalogs
@@ -235,13 +235,13 @@ is documented in the SDSS DR12 `data model for specObj-dr12.fits`_.
 
 decals-dr2-DR12Q.fits
 ---------------------
-HDU1 (the only HDU) contains Tractored DECaLS 
-photometry that is row-by-row-matched to the SDSS DR12 
+HDU1 (the only HDU) contains Tractored DECaLS
+photometry that is row-by-row-matched to the SDSS DR12
 visually inspected quasar catalog (Paris et al. 2016, in preparation, see also `Paris et al. 2014`_)
-such that the photometric parameters in row "N" of 
+such that the photometric parameters in row "N" of
 decals-dr2-DR12Q.fits matches the spectroscopic parameters in row "N" of
 DR12Q.fits. The structure of the DECaLS photometric catalog files is documented on the
-`catalogs page`_ and the spectroscopic file 
+`catalogs page`_ and the spectroscopic file
 is documented in the SDSS DR12 `data model for DR12Q.fits`_.
 
 .. _`Paris et al. 2014`: https://ui.adsabs.harvard.edu/abs/2014A%26A...563A..54P/abstract
@@ -252,9 +252,9 @@ decals-dr2-Superset_DR12Q.fits
 ------------------------------
 HDU1 (the only HDU) contains Tractored DECaLS
 photometry catalog that is row-by-row-matched to the superset of all SDSS DR12 spectroscopically
-confirmed objects that were visually inspected as possible quasars 
+confirmed objects that were visually inspected as possible quasars
 (Paris et al. 2016, in preparation, see also `Paris et al. 2014`_)
-such that the photometric parameters in row "N" of 
+such that the photometric parameters in row "N" of
 decals-dr2-Superset_DR12Q.fits matches the spectroscopic parameters in row "N" of
 Superset_DR12Q.fits. The structure of the DECaLS photometric catalog files is documented on the
 `catalogs page`_ and the spectroscopic file
@@ -269,7 +269,7 @@ Tractor Catalogs
 
 In the file listings outlined below:
 
-- brick names (**<brick>**) have the format `<AAAa>c<BBB>` where `A`, `a` and `B` are digits and `c` is either the letter `m` or `p` (e.g. `1126p222`). The names are derived from the (RA, Dec) center of the brick. The first four digits are :math:`int(RA \times 10)`, followed by `p` to denote positive Dec or `m` to denote negative Dec ("plus"/"minus"), followed by three digits of :math:`int(Dec \times 10)`. For example the case `1126p222` corresponds to (RA, Dec) = (112.6\ |deg|, +22.2\ |deg|). 
+- brick names (**<brick>**) have the format `<AAAa>c<BBB>` where `A`, `a` and `B` are digits and `c` is either the letter `m` or `p` (e.g. `1126p222`). The names are derived from the (RA, Dec) center of the brick. The first four digits are :math:`int(RA \times 10)`, followed by `p` to denote positive Dec or `m` to denote negative Dec ("plus"/"minus"), followed by three digits of :math:`int(Dec \times 10)`. For example the case `1126p222` corresponds to (RA, Dec) = (112.6\ |deg|, +22.2\ |deg|).
 
 - **<brickmin>** and **<brickmax>** denote the corners of a rectangle in (RA, Dec). Explicitly, **<brickmin>** has the format `<AAA>c<BBB>` where `<AAA>` denotes three digits of the minimum :math:`int(RA)` in degrees, <BBB> denotes three digits of the minimum :math:`int(Dec)` in degrees, and `c` uses the `p`/`m` ("plus"/"minus") format outlined in the previous bullet point. The convention is similar for  **<brickmax>** and the maximum RA and Dec. For example `000m010-010m005` would correspond to a survey region limited by :math:`0^\circ \leq RA < 10^\circ` and :math:`-10^\circ \leq Dec < -5^\circ`.
 
@@ -283,7 +283,7 @@ tractor/<AAA>/tractor-<brick>.fits
 ----------------------------------
 
 FITS binary table containing Tractor photometry, documented on the
-`catalogs page`_. 
+`catalogs page`_.
 
 .. _`catalogs page`: ../catalogs
 
@@ -438,7 +438,8 @@ the colors.
 Raw Data
 ========
 
-Raw Legacy Survey images are available through the NOAO Science Archive.  The
+
+Raw Legacy Survey images are available through the NOIRLab Science Archive.  The
 *input* data used to create the stacked images, Tractor catalogs, etc. comprises
 images taken by the dedicated DECam Legacy Survey project, as well as other
 DECam images, and images from other surveys.  These instructions are for
@@ -451,7 +452,7 @@ obtaining raw images from the DECam Legacy Survey *only*.
 4. Under "Data products - Raw data" check "Object".
 5. Optionally, you may select data from specific DECam filters, or restrict the search by other parameters such as sky coordinates, observing date, or exposure time.
 6. Click Search.
-7. The Results page offers several different ways to download the detail. See 
+7. The Results page offers several different ways to download the detail. See
    `the Tutorials page`_ for details.
 
 .. _`NOAO Science Archive`: http://portal-nvo.noao.edu

--- a/pages/dr3/catalogs.rst
+++ b/pages/dr3/catalogs.rst
@@ -154,8 +154,9 @@ which are different from those used in SDSS-I,II,III, but are the values used fo
 
 Extinction coefficients for the DECam filters also use the `Schlafly & Finkbeiner (2011)`_ values,
 with u-band computed using the same formulae and code at airmass 1.3 (Schlafly, priv. comm. decam-data list on 11/13/14).
-These coefficients are A / E(B-V) = 3.995, 3.214, 2.165, 1.592, 1.211, 1.064.
-(These are slightly different than the ones in `Schlafly & Finkbeiner 2011`_).
+These coefficients are :math:`A / E(B-V)` = 3.995, 3.214, 2.165, 1.592, 1.211, 1.064
+for the DECam :math:`u`, :math:`g`, :math:`r`, :math:`i`, :math:`z`, :math:`Y` filters,
+respectively. Note that these are *slightly* different from the coefficients in `Schlafly & Finkbeiner (2011)`_.
 
 The coefficients for the four WISE filters are derived from Fitzpatrick 1999, as recommended by Schafly & Finkbeiner,
 considered better than either the Cardelli et al 1989 curves or the newer Fitzpatrick & Massa 2009 NIR curve not vetted beyond 2 micron).

--- a/pages/dr3/catalogs.rst
+++ b/pages/dr3/catalogs.rst
@@ -112,7 +112,7 @@ Bit Value Name                        Description
  10  1024 longthin                    :math:`\gt 5\sigma` connected components with major axis :math:`\gt 200` pixels and major/minor axis :math:`\gt 0.1`.  To mask, *e.g.*, satellite trails.
 === ===== =========================== ==================================================
 
-.. _`CP Data Quality bit description`: https://www.noao.edu/noao/staff/fvaldes/CPDocPrelim/PL201_3.html
+.. _`CP Data Quality bit description`: https://legacy.noirlab.edu/noao/staff/fvaldes/CPDocPrelim/PL201_3.html
 
 Goodness-of-Fits
 ----------------

--- a/pages/dr3/description.rst
+++ b/pages/dr3/description.rst
@@ -27,7 +27,7 @@ the Blanco Telescope.
 
 Data Release 3 (DR3) is the third public data release of images and catalogs for
 the DECam Legacy Survey (DECaLS). Images from DECaLS
-g,r,z-band observations (survey program 0404; https://www.noao.edu/perl/abstract?2014B-0404)
+g,r,z-band observations (survey program 0404; https://legacy.noirlab.edu/perl/abstract?2014B-0404)
 are included from August 2014 through March 2016. DR3 also includes DECam data from a range of
 non-DECaLS surveys, including observations that were conducted from September 2012 to March 2016.
 
@@ -130,7 +130,7 @@ Sky Level
 
 The Community Pipeline removes a sky level that includes a sky pattern, an illumination correction,
 and a single scaled fringe pattern.  These steps are described here:
-https://www.noao.edu/noao/staff/fvaldes/CPDocPrelim/PL201_3.html .
+https://legacy.noirlab.edu/noao/staff/fvaldes/CPDocPrelim/PL201_3.html .
 This makes the sky level in the processed images near zero, and removes most pattern artifacts.
 A constant sky level is then added back to the image that is the mean of what was removed.
 
@@ -334,7 +334,7 @@ Brick
 
 CP
     Community Pipeline (DECam reduction pipeline operated by NOIRLab;
-    https://www.noao.edu/noao/staff/fvaldes/CPDocPrelim/PL201_3.html).
+    https://legacy.noirlab.edu/noao/staff/fvaldes/CPDocPrelim/PL201_3.html).
 
 DECaLS
     `Dark Energy Camera Legacy Survey <https://www.legacysurvey.org>`_.

--- a/pages/dr3/files.rst
+++ b/pages/dr3/files.rst
@@ -546,69 +546,9 @@ the colors.
 Raw Data
 ========
 
-Raw and Calibrated Legacy Survey images are available from the Astro Data Lab's [1]_ Science Archive through the web
-portal (http://archive.noao.edu/search/query) and an ftp server. The input data used to create the
-stacked images, Tractor catalogs, etc. comprise images taken by the dedicated DECam Legacy Survey
-project, as well as other DECam images.
+See the `raw data page`_.
 
-(i) Web interface
------------------
-
-1. Query the `Astro Data Lab's Science Archive`_.
-2. From the menu of "Available Collections" on the left, select the desired data release (e.g. DECaLS-DR3).
-3. Under "Data products - Raw data" check "Object".
-4. Optionally, you may select data from specific DECam filters, or restrict the search by other parameters such as sky coordinates, observing date, or exposure time.
-5. Click "Search".
-6. For DECaLS only images, refine the search by Proposal ID (2014B-0404) in the "Refine" tab.
-7. The Results page offers several different ways to download the data. See `the Tutorials page`_ for details.
-
-.. _`Astro Data Lab's Science Archive`: http://archive.noao.edu/search/query
-.. _`the Tutorials page`: http://archive.noao.edu/tutorials/query
-
-
-(ii) ftp sites
---------------
-
-Following the organization of the Stacked images, Raw and Calibrated DECam images are organized
-by survey brick, which are defined in the file *survey-bricks-dr3.fits.gz* for DR3. Both the main Tractor
-catalogs and Sweep catalogs include the ``BRICKNAME`` keyword (corresponding to ``<brick>`` with
-format ``<AAAa>c<BBB>)``.
-
-- Raw: ftp://archive.noao.edu/public/hlsp/decals/dr3/raw/``<AAA>/<brick>``
-- Calibrated: ftp://archive.noao.edu/public/hlsp/decals/dr3/calibrated/``<AAA>/<brick>``
-- Stacked: ftp://archive.noao.edu/public/hlsp/decals/dr3/coadd/``<AAA>/<brick>``
-
-For the calibrated images, filenames can be retrieved from the ``IMAGE_FILENAME`` keyword in each brick
-from *legacysurvey*-``<brick>``-*ccds.fits*. Additionally, each *calibrated*/``<AAA>/<brick>``
-contains an ASCII file
-with a list of ``EXPID`` and ``IMAGE_FILENAME``
-(*legacysurvey*-``<brick>``-*image_filename.txt*; see the example below).
-``EXPID`` contains the exposure number and the CCD name (Nxx or Sxx) with the format ``EXPNUM-ccd``.
-There is one entry per CCD. Often, multiple CCDs from a given file are used so there are
-fewer unique filenames than the number of CCDs. Each *legacysurvey*-``<brick>``-*image_filename.txt*
-file contains the number of unique images in the last row (File Count).
-
-For the Raw CCD images, the file naming convention has evolved during the survey. The
-corresponding files can be reconciled through the original DECam filename:
-DECam_<``EXPNUM``>.fits.fz where ``EXPNUM`` needs to be in format ``I08`` and can be retrieved
-from *legacysurvey*-``<brick>``-*ccds.fits* for each brick, and from the keyword ``DTNSANAM``
-in ``hdr[0]`` from each calibrated file.
-
-Here is an example ASCII file for a given brick: *[noao-ftp]/calibrated/006/0060p147/legacysurvey-0060p147-image_filename.txt*
-
-::
-
-   expid                                                image_filename
-   1 00483709-N25 decam/CP20151010/c4d_151011_041055_oki_g_v1.fits.fz
-   2 00483709-N26 decam/CP20151010/c4d_151011_041055_oki_g_v1.fits.fz
-   3 00483709-N29 decam/CP20151010/c4d_151011_041055_oki_g_v1.fits.fz
-   4 00483710-N25 decam/CP20151010/c4d_151011_041329_oki_r_v1.fits.fz
-   5 00483710-N26 decam/CP20151010/c4d_151011_041329_oki_r_v1.fits.fz
-   6 00483710-N29 decam/CP20151010/c4d_151011_041329_oki_r_v1.fits.fz
-   File Count: 2
-
-In the example above, there are 6 CCDs used for the stacked image, corresponding to 2 unique, multi-extension files.
-
+.. _`raw data page`: ../../rawdata
 
 |
 

--- a/pages/dr4/catalogs.rst
+++ b/pages/dr4/catalogs.rst
@@ -14,7 +14,7 @@ tractor/<AAA>/tractor-<brick>.fits
 ----------------------------------
 
 FITS binary table containing Tractor photometry. Before using these catalogs, note that there are
-`known issues`_ regarding their content and derivation. In DR4, the columns pertaining to optical data 
+`known issues`_ regarding their content and derivation. In DR4, the columns pertaining to optical data
 also have :math:`u`, :math:`i` and :math:`Y`-band entries (e.g. ``flux_u``, ``flux_i``, ``flux_Y``) but these contain only
 zeros in DR4.
 
@@ -104,9 +104,9 @@ Name                        Type         Units                 Description
 ``anymask_g``               int16                              Bitwise mask set if the central pixel from any image satisfies each condition in :math:`g`
 ``anymask_r``               int16                              Bitwise mask set if the central pixel from any image satisfies each condition in :math:`r`
 ``anymask_z``               int16                              Bitwise mask set if the central pixel from any image satisfies each condition in :math:`z`
-``allmask_g``               int16                              Bitwise mask set if the central pixel from all images satisfy each condition in :math:`g` 
-``allmask_r``               int16                              Bitwise mask set if the central pixel from all images satisfy each condition in :math:`r` 
-``allmask_z``               int16                              Bitwise mask set if the central pixel from all images satisfy each condition in :math:`z` 
+``allmask_g``               int16                              Bitwise mask set if the central pixel from all images satisfy each condition in :math:`g`
+``allmask_r``               int16                              Bitwise mask set if the central pixel from all images satisfy each condition in :math:`r`
+``allmask_z``               int16                              Bitwise mask set if the central pixel from all images satisfy each condition in :math:`z`
 ``wisemask_w1``		    uint8			       W1 bright star bitmask, :math:`2^0` :math:`(2^1)` for southward (northward) scans
 ``wisemask_w2``		    uint8			       W2 bright star bitmask, :math:`2^0` :math:`(2^1)` for southward (northward) scans
 ``psfsize_g``               float32      arcsec                Weighted average PSF FWHM in the :math:`g` band
@@ -166,7 +166,7 @@ Bit Value Name                        Description
  10  1024 longthin                    :math:`\gt 5\sigma` connected components with major axis :math:`\gt 200` pixels and major/minor axis :math:`\gt 0.1`.  To mask, *e.g.*, satellite trails.
 === ===== =========================== ==================================================
 
-.. _`CP Data Quality bit description`: https://www.noao.edu/noao/staff/fvaldes/CPDocPrelim/PL201_3.html
+.. _`CP Data Quality bit description`: https://legacy.noirlab.edu/noao/staff/fvaldes/CPDocPrelim/PL201_3.html
 
 Goodness-of-Fits
 ----------------

--- a/pages/dr4/catalogs.rst
+++ b/pages/dr4/catalogs.rst
@@ -210,8 +210,9 @@ For DR4, we calculate Galactic extinction for `BASS`_ and `MzLS`_ as if they wer
 
 Extinction coefficients for the DECam filters use the `Schlafly & Finkbeiner (2011)`_ values,
 with u-band computed using the same formulae and code at airmass 1.3 (Schlafly, priv. comm. decam-data list on 11/13/14).
-These coefficients are A / E(B-V) = 3.995, 3.214, 2.165, 1.592, 1.211, 1.064.
-(These are slightly different than the ones in `Schlafly & Finkbeiner 2011`_).
+These coefficients are :math:`A / E(B-V)` = 3.995, 3.214, 2.165, 1.592, 1.211, 1.064
+for the DECam :math:`u`, :math:`g`, :math:`r`, :math:`i`, :math:`z`, :math:`Y` filters,
+respectively. Note that these are *slightly* different from the coefficients in `Schlafly & Finkbeiner (2011)`_.
 
 The coefficients for the four WISE filters are derived from Fitzpatrick (1999), as recommended by Schafly & Finkbeiner,
 considered better than either the Cardelli et al (1989) curves or the newer Fitzpatrick & Massa (2009) NIR curve (which is not vetted beyond 2 microns).

--- a/pages/dr4/description.rst
+++ b/pages/dr4/description.rst
@@ -29,7 +29,7 @@ of extragalactic sky visible from the northern hemisphere in three optical bands
 .. _`DECaLS`: ../../decamls
 .. _`MzLS`: ../../mzls
 .. _`Tractor`: https://github.com/dstndstn/tractor
-.. _`NOIRLab Community Pipeline`: https://www.noao.edu/noao/staff/fvaldes/CPDocPrelim/PL201_3.html
+.. _`NOIRLab Community Pipeline`: https://legacy.noirlab.edu/noao/staff/fvaldes/CPDocPrelim/PL201_3.html
 .. _`Ceres solver`: http://ceres-solver.org
 .. _`SciPy`: https://www.scipy.org
 .. _`mixture-of-gaussian`: https://arxiv.org/abs/1210.6563
@@ -346,7 +346,7 @@ Tractor catalog headers ("WISEAB1", etc).
 .. _`BASS r-band`: ../../files/bass-r.txt
 .. _`MzLS z-band`: ../../files/kpzd.txt
 .. _`MzLS z-band with corrections`: ../../files/kpzdccdcorr3.txt
-.. _`Mosaic-3`: http://www-kpno.kpno.noao.edu/mosaic/index.html
+.. _`Mosaic-3`: https://noirlab.edu/science/programs/kpno/retired-instruments/mosaic
 .. _`90Prime`: https://soweb.as.arizona.edu/~tscopewiki/doku.php?id=90prime_info
 .. _`DR8 catalogs`: ../../dr8/catalogs/#galactic-extinction-coefficients
 
@@ -418,7 +418,7 @@ Brick
 
 CP
     Community Pipeline (reduction pipeline operated by NOIRLab;
-    https://www.noao.edu/noao/staff/fvaldes/CPDocPrelim/PL201_3.html).
+    https://legacy.noirlab.edu/noao/staff/fvaldes/CPDocPrelim/PL201_3.html).
 
 DECaLS
     `Dark Energy Camera Legacy Survey <https://www.legacysurvey.org/decamls>`_.

--- a/pages/dr4/files.rst
+++ b/pages/dr4/files.rst
@@ -602,47 +602,9 @@ the colors.
 Raw Data
 ========
 
-Raw and Calibrated Legacy Survey images are available from the Astro Data Lab's [1]_ Science Archive through the web
-portal (http://archive.noao.edu/search/query) and an ftp server. The input data used to create the
-stacked images, Tractor catalogs, etc. comprise images
-taken from the Mayall :math:`z`-band Legacy Survey (`MzLS`_) in the :math:`z` band, and from
-the Beijing-Arizona Sky Survey (`BASS`_) in the :math:`g` & :math:`r` bands.
+See the `raw data page`_.
 
-(i) Web interface
------------------
-
-1. Query the `Astro Data Lab's Science Archive`_.
-2. From the menu of "Available Collections" on the left, select the desired data release (e.g. LS-DR4).
-3. Under "Data products - Raw data" check "Object".
-4. Optionally, you may select data from specific filters, or restrict the search by other parameters such as sky coordinates, observing date, or exposure time.
-5. Click "Search".
-6. The Results page offers several different ways to download the data. See `the Tutorials page`_ for details.
-
-.. _`Astro Data Lab's Science Archive`: http://archive.noao.edu/search/query
-.. _`the Tutorials page`: http://archive.noao.edu/tutorials/query
-
-
-(ii) ftp sites
---------------
-
-Following the organization of the Stacked images, Raw and Calibrated images are organized
-by survey brick, which are defined in the file *survey-bricks-dr4.fits.gz* for DR4. Both the main Tractor
-catalogs and Sweep catalogs include the ``BRICKNAME`` keyword (corresponding to ``<brick>`` with
-format ``<AAAa>c<BBB>)``.
-
-- Raw: ftp://archive.noao.edu/public/hlsp/ls/dr4/raw/``<AAA>/<brick>``
-- Calibrated: ftp://archive.noao.edu/public/hlsp/ls/dr4/calibrated/``<AAA>/<brick>``
-- Stacked: ftp://archive.noao.edu/public/hlsp/ls/dr4/coadd/``<AAA>/<brick>``
-
-For the calibrated images, filenames can be retrieved from the ``IMAGE_FILENAME`` keyword in each brick
-from *legacysurvey*-``<brick>``-*ccds.fits*. Additionally, each *calibrated*/``<AAA>/<brick>``
-contains an ASCII file
-with a list of ``EXPID`` and ``IMAGE_FILENAME``
-(*legacysurvey*-``<brick>``-*image_filename.txt*).
-``EXPID`` contains the exposure number and the CCD name with the format ``EXPNUM-ccd``.
-There is one entry per CCD. Often, multiple CCDs from a given file are used so there are
-fewer unique filenames than the number of CCDs. Each *legacysurvey*-``<brick>``-*image_filename.txt*
-file contains the number of unique images in the last row (File Count).
+.. _`raw data page`: ../../rawdata
 
 |
 

--- a/pages/dr5/catalogs.rst
+++ b/pages/dr5/catalogs.rst
@@ -14,7 +14,7 @@ tractor/<AAA>/tractor-<brick>.fits
 ----------------------------------
 
 FITS binary table containing Tractor photometry. Before using these catalogs, note that there are
-`known issues`_ regarding their content and derivation. In DR5, the columns pertaining to optical data 
+`known issues`_ regarding their content and derivation. In DR5, the columns pertaining to optical data
 also have :math:`u`, :math:`i` and :math:`Y`-band entries (e.g. ``flux_u``, ``flux_i``, ``flux_Y``), but these contain only
 zeros.
 
@@ -103,9 +103,9 @@ Name                        Type         Units                 Description
 ``anymask_g``               int16                              Bitwise mask set if the central pixel from any image satisfies each condition in :math:`g`
 ``anymask_r``               int16                              Bitwise mask set if the central pixel from any image satisfies each condition in :math:`r`
 ``anymask_z``               int16                              Bitwise mask set if the central pixel from any image satisfies each condition in :math:`z`
-``allmask_g``               int16                              Bitwise mask set if the central pixel from all images satisfy each condition in :math:`g` 
-``allmask_r``               int16                              Bitwise mask set if the central pixel from all images satisfy each condition in :math:`r` 
-``allmask_z``               int16                              Bitwise mask set if the central pixel from all images satisfy each condition in :math:`z` 
+``allmask_g``               int16                              Bitwise mask set if the central pixel from all images satisfy each condition in :math:`g`
+``allmask_r``               int16                              Bitwise mask set if the central pixel from all images satisfy each condition in :math:`r`
+``allmask_z``               int16                              Bitwise mask set if the central pixel from all images satisfy each condition in :math:`z`
 ``wisemask_w1``		    uint8			       W1 bright star bitmask, :math:`2^0` :math:`(2^1)` for southward (northward) scans
 ``wisemask_w2``		    uint8			       W2 bright star bitmask, :math:`2^0` :math:`(2^1)` for southward (northward) scans
 ``psfsize_g``               float32      arcsec                Weighted average PSF FWHM in the :math:`g` band
@@ -165,7 +165,7 @@ Bit Value Name                        Description
  10  1024 longthin                    :math:`\gt 5\sigma` connected components with major axis :math:`\gt 200` pixels and major/minor axis :math:`\gt 0.1`.  To mask, *e.g.*, satellite trails.
 === ===== =========================== ==================================================
 
-.. _`CP Data Quality bit description`: https://www.noao.edu/noao/staff/fvaldes/CPDocPrelim/PL201_3.html
+.. _`CP Data Quality bit description`: https://legacy.noirlab.edu/noao/staff/fvaldes/CPDocPrelim/PL201_3.html
 
 Goodness-of-Fits
 ----------------
@@ -187,7 +187,7 @@ computed as the following sum over pixels in the blob for each object:
 .. math::
     \chi^2 = \frac{\sum \left[ \left(\mathrm{image} - \mathrm{model}\right)^2 \times \mathrm{model} \times \mathrm{inverse\, variance}\right]}{\sum \left[ \mathrm{model} \right]}
 
-The above sum is over all images contributing to a particular filter, and can be negative-valued for sources 
+The above sum is over all images contributing to a particular filter, and can be negative-valued for sources
 that have a flux measured as negative in some bands where they are not detected.
 
 Galactic Extinction Coefficients
@@ -206,7 +206,7 @@ which are different from those used in SDSS-I,II,III, but are the values used fo
 
 Extinction coefficients for the DECam filters use the `Schlafly & Finkbeiner (2011)`_ values,
 with :math:`u`-band computed using the same formulae and code at airmass 1.3 (Schlafly, priv. comm. decam-data list on 11/13/14).
-These coefficients are A / E(B-V) = 3.995, 3.214, 2.165, 1.592, 1.211, 1.064 (note that these are 
+These coefficients are A / E(B-V) = 3.995, 3.214, 2.165, 1.592, 1.211, 1.064 (note that these are
 *slightly* different from the coefficients in `Schlafly & Finkbeiner 2011`_).
 
 The coefficients for the four WISE filters are derived from `Fitzpatrick (1999)`_, as recommended by `Schlafly & Finkbeiner (2011)`_,

--- a/pages/dr5/catalogs.rst
+++ b/pages/dr5/catalogs.rst
@@ -206,8 +206,9 @@ which are different from those used in SDSS-I,II,III, but are the values used fo
 
 Extinction coefficients for the DECam filters use the `Schlafly & Finkbeiner (2011)`_ values,
 with :math:`u`-band computed using the same formulae and code at airmass 1.3 (Schlafly, priv. comm. decam-data list on 11/13/14).
-These coefficients are A / E(B-V) = 3.995, 3.214, 2.165, 1.592, 1.211, 1.064 (note that these are
-*slightly* different from the coefficients in `Schlafly & Finkbeiner 2011`_).
+These coefficients are :math:`A / E(B-V)` = 3.995, 3.214, 2.165, 1.592, 1.211, 1.064
+for the DECam :math:`u`, :math:`g`, :math:`r`, :math:`i`, :math:`z`, :math:`Y` filters,
+respectively. Note that these are *slightly* different from the coefficients in `Schlafly & Finkbeiner (2011)`_.
 
 The coefficients for the four WISE filters are derived from `Fitzpatrick (1999)`_, as recommended by `Schlafly & Finkbeiner (2011)`_,
 considered better than either the `Cardelli et al. (1989)`_ curves or the newer `Fitzpatrick & Massa (2009)`_ NIR curve (which is not vetted beyond 2 microns).

--- a/pages/dr5/description.rst
+++ b/pages/dr5/description.rst
@@ -33,7 +33,7 @@ of extragalactic sky visible from the northern hemisphere in three optical bands
 .. _`DECaLS`: ../../decamls
 .. _`MzLS`: ../../mzls
 .. _`Tractor`: https://github.com/dstndstn/tractor
-.. _`NOIRLab Community Pipeline`: https://www.noao.edu/noao/staff/fvaldes/CPDocPrelim/PL201_3.html
+.. _`NOIRLab Community Pipeline`: https://legacy.noirlab.edu/noao/staff/fvaldes/CPDocPrelim/PL201_3.html
 .. _`Ceres solver`: http://ceres-solver.org
 .. _`SciPy`: https://www.scipy.org
 .. _`mixture-of-gaussian`: https://arxiv.org/abs/1210.6563
@@ -55,7 +55,7 @@ DR5 imaging is first reduced through the `NOIRLab Community Pipeline`_ before be
 using the `Tractor`_.
 
 Images from `DECaLS`_
-:math:`g,r,z`-band observations (survey program 0404; https://www.noao.edu/perl/abstract?2014B-0404)
+:math:`g,r,z`-band observations (survey program 0404; https://legacy.noirlab.edu/perl/abstract?2014B-0404)
 are included from August 2014 through May 2017. DR5 also includes DECam data from a range of
 non-DECaLS surveys, including observations that were conducted from September 2012 to May 2017.
 
@@ -349,7 +349,7 @@ the DECam and WISE fluxes we provide should all be within a few percent of being
 .. _`BASS r-band`: ../../files/bass-r.txt
 .. _`MzLS z-band`: ../../files/kpzd.txt
 .. _`MzLS z-band with corrections`: ../../files/kpzdccdcorr3.txt
-.. _`Mosaic-3`: http://www-kpno.kpno.noao.edu/mosaic/index.html
+.. _`Mosaic-3`: https://noirlab.edu/science/programs/kpno/retired-instruments/mosaic
 .. _`90Prime`: https://soweb.as.arizona.edu/~tscopewiki/doku.php?id=90prime_info
 .. _`DR8 catalogs`: ../../dr8/catalogs/#galactic-extinction-coefficients
 
@@ -422,7 +422,7 @@ Brick
 
 CP
     Community Pipeline (reduction pipeline operated by NOIRLab;
-    https://www.noao.edu/noao/staff/fvaldes/CPDocPrelim/PL201_3.html).
+    https://legacy.noirlab.edu/noao/staff/fvaldes/CPDocPrelim/PL201_3.html).
 
 DECaLS
     `Dark Energy Camera Legacy Survey <https://www.legacysurvey.org/decamls>`_.

--- a/pages/dr5/files.rst
+++ b/pages/dr5/files.rst
@@ -615,49 +615,9 @@ Image stacks are on tangent-plane (WCS TAN) projections, 3600 |times|
 Raw Data
 ========
 
-Astro Data Lab [1]_ access to raw and calibrated images will be available a few weeks after the DR5 release date.
+See the `raw data page`_.
 
-Raw and Calibrated Legacy Survey images are available from the Astro Data Lab's Science Archive through the web
-portal (http://archive.noao.edu/search/query) and an ftp server.
-The input data used to create the
-stacked images, Tractor catalogs, etc. comprise images taken by the dedicated DECam Legacy Survey
-project, as well as other DECam images.
-
-(i) Web interface
------------------
-
-1. Query the `Astro Data Lab's Science Archive`_.
-2. From the menu of "Available Collections" on the left, select the desired data release (e.g. LS-DR5).
-3. Under "Data products - Raw data" check "Object".
-4. Optionally, you may select data from specific filters, or restrict the search by other parameters such as sky coordinates, observing date, or exposure time.
-5. Click "Search".
-6. The Results page offers several different ways to download the data. See `the Tutorials page`_ for details.
-
-.. _`Astro Data Lab's Science Archive`: http://archive.noao.edu/search/query
-.. _`the Tutorials page`: http://archive.noao.edu/tutorials/query
-
-
-(ii) ftp sites
---------------
-
-Following the organization of the Stacked images, Raw and Calibrated images are organized
-by survey brick, which are defined in the file **survey-bricks-dr5.fits.gz** for DR5. Both the main Tractor
-catalogs and Sweep catalogs include the ``BRICKNAME`` keyword (corresponding to ``<brick>`` with
-format ``<AAAa>c<BBB>)``.
-
-- Raw: ftp://archive.noao.edu/public/hlsp/ls/dr5/raw/``<AAA>/<brick>``
-- Calibrated: ftp://archive.noao.edu/public/hlsp/ls/dr5/calibrated/``<AAA>/<brick>``
-- Stacked: ftp://archive.noao.edu/public/hlsp/ls/dr5/coadd/``<AAA>/<brick>``
-
-For the calibrated images, filenames can be retrieved from the ``IMAGE_FILENAME`` keyword in each brick
-from *legacysurvey*-``<brick>``-*ccds.fits*. Additionally, each *calibrated*/``<AAA>/<brick>``
-contains an ASCII file
-with a list of ``EXPID`` and ``IMAGE_FILENAME``
-(*legacysurvey*-``<brick>``-*image_filename.txt*).
-``EXPID`` contains the exposure number and the CCD name with the format ``EXPNUM-ccd``.
-There is one entry per CCD. Often, multiple CCDs from a given file are used so there are
-fewer unique filenames than the number of CCDs. Each *legacysurvey*-``<brick>``-*image_filename.txt*
-file contains the number of unique images in the last row (File Count).
+.. _`raw data page`: ../../rawdata
 
 |
 

--- a/pages/dr6/catalogs.rst
+++ b/pages/dr6/catalogs.rst
@@ -14,7 +14,7 @@ tractor/<AAA>/tractor-<brick>.fits
 ----------------------------------
 
 FITS binary table containing Tractor photometry. Before using these catalogs, note that there are
-`known issues`_ regarding their content and derivation. In DR6, the columns pertaining to optical data 
+`known issues`_ regarding their content and derivation. In DR6, the columns pertaining to optical data
 also have :math:`u`, :math:`i` and :math:`Y`-band entries (e.g. ``flux_u``, ``flux_i``, ``flux_Y``), but these contain only
 zeros.
 
@@ -103,9 +103,9 @@ Name                        Type         Units                 Description
 ``anymask_g``               int16                              Bitwise mask set if the central pixel from any image satisfies each condition in :math:`g`
 ``anymask_r``               int16                              Bitwise mask set if the central pixel from any image satisfies each condition in :math:`r`
 ``anymask_z``               int16                              Bitwise mask set if the central pixel from any image satisfies each condition in :math:`z`
-``allmask_g``               int16                              Bitwise mask set if the central pixel from all images satisfy each condition in :math:`g` 
-``allmask_r``               int16                              Bitwise mask set if the central pixel from all images satisfy each condition in :math:`r` 
-``allmask_z``               int16                              Bitwise mask set if the central pixel from all images satisfy each condition in :math:`z` 
+``allmask_g``               int16                              Bitwise mask set if the central pixel from all images satisfy each condition in :math:`g`
+``allmask_r``               int16                              Bitwise mask set if the central pixel from all images satisfy each condition in :math:`r`
+``allmask_z``               int16                              Bitwise mask set if the central pixel from all images satisfy each condition in :math:`z`
 ``wisemask_w1``		    uint8			       W1 bright star bitmask, :math:`2^0` :math:`(2^1)` for southward (northward) scans
 ``wisemask_w2``		    uint8			       W2 bright star bitmask, :math:`2^0` :math:`(2^1)` for southward (northward) scans
 ``psfsize_g``               float32      arcsec                Weighted average PSF FWHM in the :math:`g` band
@@ -165,7 +165,7 @@ Bit Value Name                        Description
  10  1024 longthin                    :math:`\gt 5\sigma` connected components with major axis :math:`\gt 200` pixels and major/minor axis :math:`\gt 0.1`.  To mask, *e.g.*, satellite trails.
 === ===== =========================== ==================================================
 
-.. _`CP Data Quality bit description`: https://www.noao.edu/noao/staff/fvaldes/CPDocPrelim/PL201_3.html
+.. _`CP Data Quality bit description`: https://legacy.noirlab.edu/noao/staff/fvaldes/CPDocPrelim/PL201_3.html
 
 Goodness-of-Fits
 ----------------
@@ -187,7 +187,7 @@ computed as the following sum over pixels in the blob for each object:
 .. math::
     \chi^2 = \frac{\sum \left[ \left(\mathrm{image} - \mathrm{model}\right)^2 \times \mathrm{model} \times \mathrm{inverse\, variance}\right]}{\sum \left[ \mathrm{model} \right]}
 
-The above sum is over all images contributing to a particular filter, and can be negative-valued for sources 
+The above sum is over all images contributing to a particular filter, and can be negative-valued for sources
 that have a flux measured as negative in some bands where they are not detected.
 
 Galactic Extinction Coefficients
@@ -206,7 +206,7 @@ which are different from those used in SDSS-I,II,III, but are the values used fo
 
 Extinction coefficients for the DECam filters use the `Schlafly & Finkbeiner (2011)`_ values,
 with :math:`u`-band computed using the same formulae and code at airmass 1.3 (Schlafly, priv. comm. decam-data list on 11/13/14).
-These coefficients are A / E(B-V) = 3.995, 3.214, 2.165, 1.592, 1.211, 1.064 (note that these are 
+These coefficients are A / E(B-V) = 3.995, 3.214, 2.165, 1.592, 1.211, 1.064 (note that these are
 *slightly* different from the coefficients in `Schlafly & Finkbeiner 2011`_).
 
 The coefficients for the four WISE filters are derived from `Fitzpatrick (1999)`_, as recommended by `Schlafly & Finkbeiner (2011)`_,

--- a/pages/dr6/catalogs.rst
+++ b/pages/dr6/catalogs.rst
@@ -206,8 +206,9 @@ which are different from those used in SDSS-I,II,III, but are the values used fo
 
 Extinction coefficients for the DECam filters use the `Schlafly & Finkbeiner (2011)`_ values,
 with :math:`u`-band computed using the same formulae and code at airmass 1.3 (Schlafly, priv. comm. decam-data list on 11/13/14).
-These coefficients are A / E(B-V) = 3.995, 3.214, 2.165, 1.592, 1.211, 1.064 (note that these are
-*slightly* different from the coefficients in `Schlafly & Finkbeiner 2011`_).
+These coefficients are :math:`A / E(B-V)` = 3.995, 3.214, 2.165, 1.592, 1.211, 1.064
+for the DECam :math:`u`, :math:`g`, :math:`r`, :math:`i`, :math:`z`, :math:`Y` filters,
+respectively. Note that these are *slightly* different from the coefficients in `Schlafly & Finkbeiner (2011)`_.
 
 The coefficients for the four WISE filters are derived from `Fitzpatrick (1999)`_, as recommended by `Schlafly & Finkbeiner (2011)`_,
 considered better than either the `Cardelli et al. (1989)`_ curves or the newer `Fitzpatrick & Massa (2009)`_ NIR curve (which is not vetted beyond 2 microns).

--- a/pages/dr6/description.rst
+++ b/pages/dr6/description.rst
@@ -33,7 +33,7 @@ of extragalactic sky visible from the northern hemisphere in three optical bands
 .. _`DECaLS`: ../../decamls
 .. _`MzLS`: ../../mzls
 .. _`Tractor`: https://github.com/dstndstn/tractor
-.. _`NOIRLab Community Pipeline`: https://www.noao.edu/noao/staff/fvaldes/CPDocPrelim/PL201_3.html
+.. _`NOIRLab Community Pipeline`: https://legacy.noirlab.edu/noao/staff/fvaldes/CPDocPrelim/PL201_3.html
 .. _`Ceres solver`: http://ceres-solver.org
 .. _`SciPy`: https://www.scipy.org
 .. _`mixture-of-gaussian`: https://arxiv.org/abs/1210.6563
@@ -374,7 +374,7 @@ we provide should all be within a few percent of being on an AB system.
 .. _`old filter curve for BASS r-band`: ../../files/bass-r.txt
 .. _`MzLS z-band`: ../../files/kpzd.txt
 .. _`MzLS z-band with corrections`: ../../files/kpzdccdcorr3.txt
-.. _`Mosaic-3`: http://www-kpno.kpno.noao.edu/mosaic/index.html
+.. _`Mosaic-3`: https://noirlab.edu/science/programs/kpno/retired-instruments/mosaic
 .. _`90Prime`: https://soweb.as.arizona.edu/~tscopewiki/doku.php?id=90prime_info
 .. _`DR8 catalogs`: ../../dr8/catalogs/#galactic-extinction-coefficients
 
@@ -479,7 +479,7 @@ Brick
 
 CP
     Community Pipeline (reduction pipeline operated by NOIRLab;
-    https://www.noao.edu/noao/staff/fvaldes/CPDocPrelim/PL201_3.html).
+    https://legacy.noirlab.edu/noao/staff/fvaldes/CPDocPrelim/PL201_3.html).
 
 DECaLS
     `Dark Energy Camera Legacy Survey <https://www.legacysurvey.org/decamls>`_.

--- a/pages/dr6/files.rst
+++ b/pages/dr6/files.rst
@@ -616,49 +616,9 @@ Image stacks are on tangent-plane (WCS TAN) projections, 3600 |times|
 Raw Data
 ========
 
-Astro Data Lab [1]_ access to raw and calibrated images will be available a few weeks after the DR6 release date.
+See the `raw data page`_.
 
-Raw and Calibrated Legacy Survey images are available from the Astro Data Lab's Science Archive through the web
-portal (http://archive.noao.edu/search/query) and an ftp server.
-The input data used to create the
-stacked images, Tractor catalogs, etc. comprise images taken by the dedicated DECam Legacy Survey
-project, as well as other DECam images.
-
-(i) Web interface
------------------
-
-1. Query the `Astro Data Lab's Science Archive`_.
-2. From the menu of "Available Collections" on the left, select the desired data release (e.g. LS-DR6).
-3. Under "Data products - Raw data" check "Object".
-4. Optionally, you may select data from specific filters, or restrict the search by other parameters such as sky coordinates, observing date, or exposure time.
-5. Click "Search".
-6. The Results page offers several different ways to download the data. See `the Tutorials page`_ for details.
-
-.. _`Astro Data Lab's Science Archive`: http://archive.noao.edu/search/query
-.. _`the Tutorials page`: http://archive.noao.edu/tutorials/query
-
-
-(ii) ftp sites
---------------
-
-Following the organization of the Stacked images, Raw and Calibrated images are organized
-by survey brick, which are defined in the file **survey-bricks-dr6.fits.gz** for DR6. Both the main Tractor
-catalogs and Sweep catalogs include the ``BRICKNAME`` keyword (corresponding to ``<brick>`` with
-format ``<AAAa>c<BBB>)``.
-
-- Raw: ftp://archive.noao.edu/public/hlsp/ls/dr6/raw/``<AAA>/<brick>``
-- Calibrated: ftp://archive.noao.edu/public/hlsp/ls/dr6/calibrated/``<AAA>/<brick>``
-- Stacked: ftp://archive.noao.edu/public/hlsp/ls/dr6/coadd/``<AAA>/<brick>``
-
-For the calibrated images, filenames can be retrieved from the ``IMAGE_FILENAME`` keyword in each brick
-from *legacysurvey*-``<brick>``-*ccds.fits*. Additionally, each *calibrated*/``<AAA>/<brick>``
-contains an ASCII file
-with a list of ``EXPID`` and ``IMAGE_FILENAME``
-(*legacysurvey*-``<brick>``-*image_filename.txt*).
-``EXPID`` contains the exposure number and the CCD name with the format ``EXPNUM-ccd``.
-There is one entry per CCD. Often, multiple CCDs from a given file are used so there are
-fewer unique filenames than the number of CCDs. Each *legacysurvey*-``<brick>``-*image_filename.txt*
-file contains the number of unique images in the last row (File Count).
+.. _`raw data page`: ../../rawdata
 
 |
 

--- a/pages/dr7/catalogs.rst
+++ b/pages/dr7/catalogs.rst
@@ -243,8 +243,9 @@ which are different from those used in SDSS-I,II,III, but are the values used fo
 
 Extinction coefficients for the DECam filters use the `Schlafly & Finkbeiner (2011)`_ values,
 with :math:`u`-band computed using the same formulae and code at airmass 1.3 (Schlafly, priv. comm. decam-data list on 11/13/14).
-These coefficients are :math:`A / E(B-V)` = 3.995, 3.214, 2.165, 1.592, 1.211, 1.064 (note that these are
-*slightly* different from the coefficients in `Schlafly & Finkbeiner 2011`_).
+These coefficients are :math:`A / E(B-V)` = 3.995, 3.214, 2.165, 1.592, 1.211, 1.064
+for the DECam :math:`u`, :math:`g`, :math:`r`, :math:`i`, :math:`z`, :math:`Y` filters,
+respectively. Note that these are *slightly* different from the coefficients in `Schlafly & Finkbeiner (2011)`_.
 
 The coefficients for the four WISE filters are derived from `Fitzpatrick (1999)`_, as recommended by `Schlafly & Finkbeiner (2011)`_,
 considered better than either the `Cardelli et al. (1989)`_ curves or the newer `Fitzpatrick & Massa (2009)`_ NIR curve (which is not vetted beyond 2 microns).

--- a/pages/dr7/catalogs.rst
+++ b/pages/dr7/catalogs.rst
@@ -202,7 +202,7 @@ Bit Value Name                        Description
  10  1024 longthin                    :math:`\gt 5\sigma` connected components with major axis :math:`\gt 200` pixels and major/minor axis :math:`\gt 0.1`.  To mask, *e.g.*, satellite trails.
 === ===== =========================== ==================================================
 
-.. _`CP Data Quality bit description`: https://www.noao.edu/noao/staff/fvaldes/CPDocPrelim/PL201_3.html
+.. _`CP Data Quality bit description`: https://legacy.noirlab.edu/noao/staff/fvaldes/CPDocPrelim/PL201_3.html
 
 Goodness-of-Fits
 ----------------

--- a/pages/dr7/description.rst
+++ b/pages/dr7/description.rst
@@ -37,7 +37,7 @@ An overview of the surveys is available in `Dey et al. (2019)`_.
 .. _`DECaLS`: ../../decamls
 .. _`MzLS`: ../../mzls
 .. _`Tractor`: https://github.com/dstndstn/tractor
-.. _`NOIRLab Community Pipeline`: https://www.noao.edu/noao/staff/fvaldes/CPDocPrelim/PL201_3.html
+.. _`NOIRLab Community Pipeline`: https://legacy.noirlab.edu/noao/staff/fvaldes/CPDocPrelim/PL201_3.html
 .. _`Ceres solver`: http://ceres-solver.org
 .. _`SciPy`: https://www.scipy.org
 .. _`mixture-of-gaussian`: https://arxiv.org/abs/1210.6563
@@ -65,7 +65,7 @@ processed using the `Tractor`_. DR7 also includes `WISE`_ fluxes from `year 4 of
 force-photometered in the `unWISE`_ maps at the locations of Legacy Surveys optical sources.
 
 Images from `DECaLS`_
-:math:`g,r,z`-band observations (survey program 0404; https://www.noao.edu/perl/abstract?2014B-0404)
+:math:`g,r,z`-band observations (survey program 0404; https://legacy.noirlab.edu/perl/abstract?2014B-0404)
 are included from 12th August 2013 through 18th March 2018. DR7 also includes DECam data from a range of
 non-DECaLS surveys, including observations that were conducted from August 2013 to March 2018.
 
@@ -416,7 +416,7 @@ systematics are stable at the 0.1% level.
 .. _`DECaLS g-band`: ../../files/decam.g.am1p4.dat.txt
 .. _`DECaLS r-band`: ../../files/decam.r.am1p4.dat.txt
 .. _`DECaLS z-band`: ../../files/decam.z.am1p4.dat.txt
-.. _`Mosaic-3`: http://www-kpno.kpno.noao.edu/mosaic/index.html
+.. _`Mosaic-3`: https://noirlab.edu/science/programs/kpno/retired-instruments/mosaic
 .. _`90Prime`: https://soweb.as.arizona.edu/~tscopewiki/doku.php?id=90prime_info
 .. _`DR8 catalogs`: ../../dr8/catalogs/#galactic-extinction-coefficients
 
@@ -482,7 +482,7 @@ Code Versions
 * `LegacyPipe <https://github.com/legacysurvey/legacypipe>`_: Most bricks were run with dr7v3.31. A few were finished with dr7v3.32. The version used is documented in the Tractor header card ``LEGPIPEV``.
 * `Astrometry.net <https://github.com/dstndstn/astrometry.net>`_: 0.74.
 * `Tractor <https://github.com/dstndstn/tractor>`_: dr7.0.
-* `NOIRLab Community Pipeline <https://www.noao.edu/noao/staff/fvaldes/CPDocPrelim/PL201_3.html>`_: mixture of versions; recorded as ``PLVER``.
+* `NOIRLab Community Pipeline <https://legacy.noirlab.edu/noao/staff/fvaldes/CPDocPrelim/PL201_3.html>`_: mixture of versions; recorded as ``PLVER``.
 * `SourceExtractor <http://www.astromatic.net/software/sextractor>`_: 2.19.5.
 * `PSFEx <http://www.astromatic.net/software/psfex>`_: 3.17.1.
 
@@ -508,7 +508,7 @@ Brick
 
 CP
     Community Pipeline (reduction pipeline operated by NOIRLab;
-    https://www.noao.edu/noao/staff/fvaldes/CPDocPrelim/PL201_3.html).
+    https://legacy.noirlab.edu/noao/staff/fvaldes/CPDocPrelim/PL201_3.html).
 
 DECaLS
     `Dark Energy Camera Legacy Survey <https://www.legacysurvey.org/decamls>`_.

--- a/pages/dr7/files.rst
+++ b/pages/dr7/files.rst
@@ -695,49 +695,9 @@ Image stacks are on tangent-plane (WCS TAN) projections, 3600 |times|
 Raw Data
 ========
 
-Astro Data Lab [1]_ access to raw and calibrated images will be available a few weeks after the DR7 release date.
+See the `raw data page`_.
 
-Raw and Calibrated Legacy Survey images are available from the Astro Data Lab Science Archive through the web
-portal (http://archive.noao.edu/search/query) and an ftp server.
-The input data used to create the
-stacked images, Tractor catalogs, etc. comprise images taken by the dedicated DECam Legacy Survey
-project, as well as other DECam images.
-
-(i) Web interface
------------------
-
-1. Query the `Astro Data Lab's Science Archive`_.
-2. From the menu of "Available Collections" on the left, select the desired data release (e.g. LS-DR7).
-3. Under "Data products - Raw data" check "Object".
-4. Optionally, you may select data from specific filters, or restrict the search by other parameters such as sky coordinates, observing date, or exposure time.
-5. Click "Search".
-6. The Results page offers several different ways to download the data. See `the Tutorials page`_ for details.
-
-.. _`Astro Data Lab's Science Archive`: http://archive.noao.edu/search/query
-.. _`the Tutorials page`: http://archive.noao.edu/tutorials/query
-
-
-(ii) ftp sites
---------------
-
-Following the organization of the Stacked images, Raw and Calibrated images are organized
-by survey brick, which are defined in the file **survey-bricks-dr7.fits.gz** for DR7. Both the main Tractor
-catalogs and Sweep catalogs include the ``BRICKNAME`` keyword (corresponding to ``<brick>`` with
-format ``<AAAa>c<BBB>)``.
-
-- Raw: ftp://archive.noao.edu/public/hlsp/ls/dr7/raw/``<AAA>/<brick>``
-- Calibrated: ftp://archive.noao.edu/public/hlsp/ls/dr7/calibrated/``<AAA>/<brick>``
-- Stacked: ftp://archive.noao.edu/public/hlsp/ls/dr7/coadd/``<AAA>/<brick>``
-
-For the calibrated images, filenames can be retrieved from the ``IMAGE_FILENAME`` keyword in each brick
-from *legacysurvey*-``<brick>``-*ccds.fits*. Additionally, each *calibrated*/``<AAA>/<brick>``
-contains an ASCII file
-with a list of ``EXPID`` and ``IMAGE_FILENAME``
-(*legacysurvey*-``<brick>``-*image_filename.txt*).
-``EXPID`` contains the exposure number and the CCD name with the format ``EXPNUM-ccd``.
-There is one entry per CCD. Often, multiple CCDs from a given file are used so there are
-fewer unique filenames than the number of CCDs. Each *legacysurvey*-``<brick>``-*image_filename.txt*
-file contains the number of unique images in the last row (File Count).
+.. _`raw data page`: ../../rawdata
 
 |
 

--- a/pages/dr8/bitmasks.rst
+++ b/pages/dr8/bitmasks.rst
@@ -15,7 +15,7 @@ enumerated as a power (i.e. ``7`` written in a column of bits means `two-to-the-
 
 See also the `legacypipe bitmask definitions`_.
 Note that the difference between bits 0, 1, 2, 3 for ``BRIGHTBLOB`` as compared to bits 1, 11, 12 and 13 for ``MASKBITS`` is that
-``BRIGHTBLOB`` is set based on an *initial* position (the source detection integer pixel peak), while ``MASKBITS`` is set *after* 
+``BRIGHTBLOB`` is set based on an *initial* position (the source detection integer pixel peak), while ``MASKBITS`` is set *after*
 fitting has finished (i.e., on the final brick pixel position). This can lead to slight differences (~0.15%) in the areas
 covered by the ``MASKBITS`` and ``BRIGHTBLOB`` masks.
 
@@ -67,8 +67,8 @@ Bit Name          Description
 ===========================
 
 ``ANYMASK_X`` denotes a source that touches a bad pixel in *any* of a set of overlapping :math:`X`-band images whereas
-``ALLMASK_X`` denotes a source that touches a bad pixel in *all* of a set of overlapping :math:`X`-band images. 
-See, also, the `legacypipe bitmask definitions`_. The 
+``ALLMASK_X`` denotes a source that touches a bad pixel in *all* of a set of overlapping :math:`X`-band images.
+See, also, the `legacypipe bitmask definitions`_. The
 ``ANYMASK`` and ``ALLMASK`` bit masks are defined as follows, mostly from the CP (NOIRLab Community Pipeline) `Data Quality bits`_,
 which we `map to the values in the table`_.
 
@@ -86,7 +86,7 @@ Bit Name        Description
  11 ``OUTLIER`` marked as touching an outlier pixel by ``legacypipe`` itself
 === =========== =========================
 
-.. _`Data Quality bits`: https://www.noao.edu/noao/staff/fvaldes/CPDocPrelim/PL201_3.html
+.. _`Data Quality bits`: https://legacy.noirlab.edu/noao/staff/fvaldes/CPDocPrelim/PL201_3.html
 .. _`map to the values in the table`: https://github.com/legacysurvey/legacypipe/blob/14c49362418b85a591f48eaa394205ffb0321777/py/legacypipe/image.py#L27
 
 ``WISEMASK_W1``/``WISEMASK_W2``

--- a/pages/dr8/catalogs.rst
+++ b/pages/dr8/catalogs.rst
@@ -218,7 +218,7 @@ computed as the following sum over pixels in the blob for each object:
 .. math::
     \chi^2 = \frac{\sum \left[ \left(\mathrm{image} - \mathrm{model}\right)^2 \times \mathrm{model} \times \mathrm{inverse\, variance}\right]}{\sum \left[ \mathrm{model} \right]}
 
-The above sum is over all images contributing to a particular filter, and can be negative-valued for sources 
+The above sum is over all images contributing to a particular filter, and can be negative-valued for sources
 that have a flux measured as negative in some bands where they are not detected.
 
 The final, additional moropholigical type is "DUP." This type is set for Gaia sources that are coincident with, and so have been fit by, an extended source.
@@ -234,11 +234,12 @@ with 1 representing a fully transparent region of the Milky Way and 0 representi
 The value can slightly exceed unity owing to noise in the `SFD98`_ maps, although it is never below 0.
 
 Eddie Schlafly has computed the extinction coefficients for the DECam filters through airmass=1.3, computed for a 7000K source spectrum as was
-done in the Appendix of `Schlafly & Finkbeiner (2011)`_. 
-These coefficients are A / E(B-V) = 3.995, 3.214, 2.165, 1.592, 1.211, 1.064 (note that these are
-*slightly* different from the coefficients in `Schlafly & Finkbeiner 2011`_).
-The coefficients are multiplied by the SFD98 E(B-V) values at the coordinates
-of each object to derive the :math:`g`, :math:`r` and :math:`z` ``mw_transmission`` values in the Legacy Surveys catalogs. The coefficients at different airmasses 
+done in the Appendix of `Schlafly & Finkbeiner (2011)`_.
+These coefficients are :math:`A / E(B-V)` = 3.995, 3.214, 2.165, 1.592, 1.211, 1.064
+for the DECam :math:`u`, :math:`g`, :math:`r`, :math:`i`, :math:`z`, :math:`Y` filters,
+respectively. Note that these are *slightly* different from the coefficients in `Schlafly & Finkbeiner (2011)`_.
+The coefficients are multiplied by the `SFD98`_ E(B-V) values at the coordinates
+of each object to derive the :math:`g`, :math:`r` and :math:`z` ``mw_transmission`` values in the Legacy Surveys catalogs. The coefficients at different airmasses
 only change by a small amount, with the largest effect in :math:`g`-band where the coefficient would be 3.219 at airmass=1 and 3.202 at airmass=2.
 
 We calculate Galactic extinction for `BASS`_ and `MzLS`_ as if they are on the DECam filter system.

--- a/pages/dr8/description.rst
+++ b/pages/dr8/description.rst
@@ -37,7 +37,7 @@ An overview of the surveys is available in `Dey et al. (2019)`_.
 .. _`DECaLS`: ../../decamls
 .. _`MzLS`: ../../mzls
 .. _`Tractor`: https://github.com/dstndstn/tractor
-.. _`NOIRLab Community Pipeline`: https://www.noao.edu/noao/staff/fvaldes/CPDocPrelim/PL201_3.html
+.. _`NOIRLab Community Pipeline`: https://legacy.noirlab.edu/noao/staff/fvaldes/CPDocPrelim/PL201_3.html
 .. _`Ceres solver`: http://ceres-solver.org
 .. _`SciPy`: https://www.scipy.org
 .. _`mixture-of-Gaussians`: https://arxiv.org/abs/1210.6563
@@ -54,7 +54,7 @@ An overview of the surveys is available in `Dey et al. (2019)`_.
 .. _`DESI`: https://desi.lbl.gov
 .. _`WISE`: http://wise.ssl.berkeley.edu
 .. _`year 4 of NEOWISE-Reactivation`: http://wise2.ipac.caltech.edu/docs/release/neowise/neowise_2018_release_intro.html
-.. _`survey program 0404`: https://www.noao.edu/perl/abstract?2014B-0404
+.. _`survey program 0404`: https://legacy.noirlab.edu/perl/abstract?2014B-0404
 .. _`Dark Energy Survey`: https://www.darkenergysurvey.org
 
 Contents of DR8
@@ -473,10 +473,10 @@ we provide should all be within a few percent of being on an AB system.
 .. _`DECaLS g-band`: ../../files/decam.g.am1p4.dat.txt
 .. _`DECaLS r-band`: ../../files/decam.r.am1p4.dat.txt
 .. _`DECaLS z-band`: ../../files/decam.z.am1p4.dat.txt
-.. _`Mosaic-3`: http://www-kpno.kpno.noao.edu/mosaic/index.html
+.. _`Mosaic-3`: https://noirlab.edu/science/programs/kpno/retired-instruments/mosaic
 .. _`90Prime`: https://soweb.as.arizona.edu/~tscopewiki/doku.php?id=90prime_info
-.. _`DECam`: http://www.ctio.noao.edu/noao/node/1033
-.. _`Dark Energy Camera`: http://www.ctio.noao.edu/noao/node/1033
+.. _`DECam`: https://noirlab.edu/science/programs/ctio/instruments/Dark-Energy-Camera
+.. _`Dark Energy Camera`: https://noirlab.edu/science/programs/ctio/instruments/Dark-Energy-Camera
 .. _`DR8 catalogs`: ../../dr8/catalogs/#galactic-extinction-coefficients
 
 
@@ -553,7 +553,7 @@ Code Versions
 * `LegacyPipe <https://github.com/legacysurvey/legacypipe>`_: Versions from dr8v1.2 to dr8v3.2. The version used is documented in the Tractor header card ``LEGPIPEV``.
 * `Astrometry.net <https://github.com/dstndstn/astrometry.net>`_: 0.78.
 * `Tractor <https://github.com/dstndstn/tractor>`_: dr8.1.
-* `NOIRLab Community Pipeline <https://www.noao.edu/noao/staff/fvaldes/CPDocPrelim/PL201_3.html>`_: A mixture of versions; recorded in the `survey-ccds-* files`_ as ``plver``.
+* `NOIRLab Community Pipeline <https://legacy.noirlab.edu/noao/staff/fvaldes/CPDocPrelim/PL201_3.html>`_: A mixture of versions; recorded in the `survey-ccds-* files`_ as ``plver``.
 * `SourceExtractor <http://www.astromatic.net/software/sextractor>`_: 2.25.0
 * `PSFEx <http://www.astromatic.net/software/psfex>`_: 3.21.1
 
@@ -579,7 +579,7 @@ Brick
     are performed within bricks of size approximately 0.25\ |deg| |times| 0.25\ |deg|.
 
 CP
-    Community Pipeline (`reduction pipeline operated by NOIRLab <https://www.noao.edu/noao/staff/fvaldes/CPDocPrelim/PL201_3.html>`_).
+    Community Pipeline (`reduction pipeline operated by NOIRLab <https://legacy.noirlab.edu/noao/staff/fvaldes/CPDocPrelim/PL201_3.html>`_).
 
 DECaLS
     `Dark Energy Camera Legacy Survey <https://www.legacysurvey.org/decamls>`_.

--- a/pages/dr8/files.rst
+++ b/pages/dr8/files.rst
@@ -1004,48 +1004,10 @@ We don't expect that most users will need a description of these files, but `con
 
 Raw Data
 ========
-Astro Data Lab [1]_ access to raw and calibrated images will be available a few weeks after the DR8 release date.
 
-Raw and Calibrated Legacy Survey images are available from the Astro Data Lab's Science Archive through the web
-portal (http://archive.noao.edu/search/query) and an ftp server.
-The input data used to create the
-stacked images, Tractor `catalogs`_, etc. comprise images taken by the dedicated `DESI`_ Legacy Imaging Surveys
-project, as well as other images from NOIRLab telescopes.
+See the `raw data page`_.
 
-(i) Web interface
------------------
-
-1. Query the `Astro Data Lab's Science Archive`_.
-2. From the menu of "Available Collections" on the left, select the desired data release (e.g. LS-DR8).
-3. Under "Data products - Raw data" check "Object".
-4. Optionally, you may select data from specific filters, or restrict the search by other parameters such as sky coordinates, observing date, or exposure time.
-5. Click "Search".
-6. The Results page offers several different ways to download the data. See `the Tutorials page`_ for details.
-
-.. _`Astro Data Lab's Science Archive`: http://archive.noao.edu/search/query
-.. _`the Tutorials page`: http://archive.noao.edu/tutorials/query
-
-
-(ii) ftp sites
---------------
-
-Following the organization of the Stacked images, Raw and Calibrated images are organized
-by survey brick, which are defined in the file **survey-bricks-dr8.fits.gz** for DR8. Both the main Tractor
-catalogs and Sweep catalogs include the ``BRICKNAME`` keyword (corresponding to ``<brick>`` with
-format ``<AAAa>c<BBB>)``.
-
-- Raw: ftp://archive.noao.edu/public/hlsp/ls/dr8/raw/``<AAA>/<brick>``
-- Calibrated: ftp://archive.noao.edu/public/hlsp/ls/dr8/calibrated/``<AAA>/<brick>``
-- Stacked: ftp://archive.noao.edu/public/hlsp/ls/dr8/coadd/``<AAA>/<brick>``
-
-For the calibrated images, filenames can be retrieved from the ``IMAGE_FILENAME`` keyword in each brick
-from *legacysurvey*-``<brick>``-*ccds.fits*. Additionally, each *calibrated*/``<AAA>/<brick>``
-contains an ASCII file with a list of ``EXPID`` and ``IMAGE_FILENAME``
-(*legacysurvey*-``<brick>``-*image_filename.txt*).
-``EXPID`` contains the exposure number and the CCD name with the format ``EXPNUM-ccd``.
-There is one entry per CCD. Often, multiple CCDs from a given file are used so there are
-fewer unique filenames than the number of CCDs. Each *legacysurvey*-``<brick>``-*image_filename.txt*
-file contains the number of unique images in the last row (File Count).
+.. _`raw data page`: ../../rawdata
 
 |
 

--- a/pages/dr8/issues.rst
+++ b/pages/dr8/issues.rst
@@ -93,7 +93,7 @@ for these 4 quantities in the DR8 documentation were originally incorrect. These
 .. _`to fix a different bug in the reduction process`: https://github.com/legacysurvey/legacypipe/commit/a10ecc33247ec615ec1d8401cef2e0787f91a8fc
 .. _`Legacy Surveys website`: https://github.com/legacysurvey/legacysurvey/issues
 .. _`legacypipe pipeline`: https://github.com/legacysurvey/legacypipe/issues?q=is:issue+sort:updated-desc
-.. _`DECam CCDs page`: http://www.ctio.noao.edu/noao/content/Status-DECam-CCDs
+.. _`DECam CCDs page`: https://noirlab.edu/science/programs/ctio/instruments/Dark-Energy-Camera/Status-DECam-CCDs
 .. _`DECaLS`: ../../decamls
 .. _`Tractor catalogs`: ../catalogs
 .. _`coadd files`: ../files/#image-stacks-region-coadd
@@ -101,4 +101,3 @@ for these 4 quantities in the DR8 documentation were originally incorrect. These
 .. _`viewer`: https://www.legacysurvey.org/viewer
 .. _`Andromeda`: https://www.legacysurvey.org/viewer?ra=10.6801&dec=41.2757&zoom=10&layer=dr8
 .. _`M13`: https://www.legacysurvey.org/viewer?ra=250.4306&dec=36.4666&zoom=10&layer=dr8
-

--- a/pages/dr9/bitmasks.rst
+++ b/pages/dr9/bitmasks.rst
@@ -94,7 +94,7 @@ Bit Name        Description
  11 ``OUTLIER`` marked as touching an outlier pixel by ``legacypipe`` itself
 === =========== ==========================
 
-.. _`Data Quality bits`: https://www.noao.edu/noao/staff/fvaldes/CPDocPrelim/PL201_3.html
+.. _`Data Quality bits`: https://legacy.noirlab.edu/noao/staff/fvaldes/CPDocPrelim/PL201_3.html
 .. _`map to the values in the table`: https://github.com/legacysurvey/legacypipe/blob/14c49362418b85a591f48eaa394205ffb0321777/py/legacypipe/image.py#L27
 
 ``WISEMASK_W1``/``WISEMASK_W2``

--- a/pages/dr9/catalogs.rst
+++ b/pages/dr9/catalogs.rst
@@ -243,7 +243,7 @@ computed as the following sum over pixels in the blob for each object:
 .. math::
     \chi^2 = \frac{\sum \left[ \left(\mathrm{image} - \mathrm{model}\right)^2 \times \mathrm{model} \times \mathrm{inverse\, variance}\right]}{\sum \left[ \mathrm{model} \right]}
 
-The above sum is over all images contributing to a particular filter, and can be negative-valued for sources 
+The above sum is over all images contributing to a particular filter, and can be negative-valued for sources
 that have a flux measured as negative in some bands where they are not detected.
 
 The final, additional moropholigical type is "DUP." This type is set for Gaia sources that are coincident with, and so have been fit by, an extended source.
@@ -260,11 +260,12 @@ with 1 representing a fully transparent region of the Milky Way and 0 representi
 The value can slightly exceed unity owing to noise in the `SFD98`_ maps, although it is never below 0.
 
 Eddie Schlafly has computed the extinction coefficients for the DECam filters through airmass=1.3, computed for a 7000K source spectrum as was
-done in the Appendix of `Schlafly & Finkbeiner (2011)`_. 
-These coefficients are A / E(B-V) = 3.995, 3.214, 2.165, 1.592, 1.211, 1.064 (note that these are
-*slightly* different from the coefficients in `Schlafly & Finkbeiner 2011`_).
-The coefficients are multiplied by the SFD98 E(B-V) values at the coordinates
-of each object to derive the :math:`g`, :math:`r` and :math:`z` ``mw_transmission`` values in the Legacy Surveys catalogs. The coefficients at different airmasses 
+done in the Appendix of `Schlafly & Finkbeiner (2011)`_.
+These coefficients are :math:`A / E(B-V)` = 3.995, 3.214, 2.165, 1.592, 1.211, 1.064
+for the DECam :math:`u`, :math:`g`, :math:`r`, :math:`i`, :math:`z`, :math:`Y` filters,
+respectively. Note that these are *slightly* different from the coefficients in `Schlafly & Finkbeiner (2011)`_.
+The coefficients are multiplied by the `SFD98`_ E(B-V) values at the coordinates
+of each object to derive the :math:`g`, :math:`r` and :math:`z` ``mw_transmission`` values in the Legacy Surveys catalogs. The coefficients at different airmasses
 only change by a small amount, with the largest effect in :math:`g`-band where the coefficient would be 3.219 at airmass=1 and 3.202 at airmass=2.
 
 We calculate Galactic extinction for `BASS`_ and `MzLS`_ as if they are on the DECam filter system.

--- a/pages/dr9/description.rst
+++ b/pages/dr9/description.rst
@@ -37,7 +37,7 @@ An overview of the surveys is available in `Dey et al. (2019)`_.
 .. _`DECaLS`: ../../decamls
 .. _`MzLS`: ../../mzls
 .. _`Tractor`: https://github.com/dstndstn/tractor
-.. _`NOIRLab Community Pipeline`: https://www.noao.edu/noao/staff/fvaldes/CPDocPrelim/PL201_3.html
+.. _`NOIRLab Community Pipeline`: https://legacy.noirlab.edu/noao/staff/fvaldes/CPDocPrelim/PL201_3.html
 .. _`Ceres solver`: http://ceres-solver.org
 .. _`SciPy`: https://www.scipy.org
 .. _`mixture-of-Gaussians`: https://arxiv.org/abs/1210.6563
@@ -54,7 +54,7 @@ An overview of the surveys is available in `Dey et al. (2019)`_.
 .. _`DESI`: https://desi.lbl.gov
 .. _`WISE`: http://wise.ssl.berkeley.edu
 .. _`year 6 of NEOWISE-Reactivation`: http://wise2.ipac.caltech.edu/docs/release/neowise/neowise_2020_release_intro.html
-.. _`survey program 0404`: https://www.noao.edu/perl/abstract?2014B-0404
+.. _`survey program 0404`: https://legacy.noirlab.edu/perl/abstract?2014B-0404
 .. _`Dark Energy Survey`: https://www.darkenergysurvey.org
 
 Contents of DR9
@@ -236,7 +236,7 @@ More examples are available on the `list of URL/cutout patterns that are support
 .. _`random catalogs`: ../files/#random-catalogs-randoms
 .. _`image stacks`: ../files/#image-stacks-region-coadd
 .. _`the Sky viewer`: https://www.legacysurvey.org/viewer
-.. _`the NOIRLab portal`: http://archive.noao.edu/search/query
+.. _`the NOIRLab portal`: https://astroarchive.noirlab.edu/portal/search/#/search-form
 
 Source Detection
 ================
@@ -536,10 +536,10 @@ we provide should all be within a few percent of being on an AB system.
 .. _`DECaLS g-band`: ../../files/decam.g.am1p4.dat.txt
 .. _`DECaLS r-band`: ../../files/decam.r.am1p4.dat.txt
 .. _`DECaLS z-band`: ../../files/decam.z.am1p4.dat.txt
-.. _`Mosaic-3`: http://www-kpno.kpno.noao.edu/mosaic/index.html
+.. _`Mosaic-3`: https://noirlab.edu/science/programs/kpno/retired-instruments/mosaic
 .. _`90Prime`: https://soweb.as.arizona.edu/~tscopewiki/doku.php?id=90prime_info
-.. _`DECam`: http://www.ctio.noao.edu/noao/node/1033
-.. _`Dark Energy Camera`: http://www.ctio.noao.edu/noao/node/1033
+.. _`DECam`: https://noirlab.edu/science/programs/ctio/instruments/Dark-Energy-Camera
+.. _`Dark Energy Camera`: https://noirlab.edu/science/programs/ctio/instruments/Dark-Energy-Camera
 .. _`catalogs page`: ../catalogs/#galactic-extinction-coefficients
 
 
@@ -615,7 +615,7 @@ Code Versions
 * `LegacyPipe <https://github.com/legacysurvey/legacypipe>`_: A mix of versions; dr9-m33-1-g33038aa1, DR9.6.2, DR9.6.4, DR9.6.5, DR9.6.5-4-gbb698724 and DR9.6.7. The version used is documented in the Tractor header card ``LEGPIPEV``.
 * `Astrometry.net <https://github.com/dstndstn/astrometry.net>`_: 0.84
 * `Tractor <https://github.com/dstndstn/tractor>`_: dr9.5
-* `NOIRLab Community Pipeline <https://www.noao.edu/noao/staff/fvaldes/CPDocPrelim/PL201_3.html>`_: A mixture of versions; recorded in the `survey-ccds-* files`_ as ``plver``.
+* `NOIRLab Community Pipeline <https://legacy.noirlab.edu/noao/staff/fvaldes/CPDocPrelim/PL201_3.html>`_: A mixture of versions; recorded in the `survey-ccds-* files`_ as ``plver``.
 * `SourceExtractor <http://www.astromatic.net/software/sextractor>`_: 2.25.2
 * `PSFEx <http://www.astromatic.net/software/psfex>`_: 3.22.1
 
@@ -642,7 +642,7 @@ Brick
     are performed within bricks of size approximately 0.25\ |deg| |times| 0.25\ |deg|.
 
 CP
-    Community Pipeline (`reduction pipeline operated by NOIRLab <https://www.noao.edu/noao/staff/fvaldes/CPDocPrelim/PL201_3.html>`_).
+    Community Pipeline (`reduction pipeline operated by NOIRLab <https://legacy.noirlab.edu/noao/staff/fvaldes/CPDocPrelim/PL201_3.html>`_).
 
 DECaLS
     `Dark Energy Camera Legacy Survey <https://www.legacysurvey.org/decamls>`_.

--- a/pages/dr9/files.rst
+++ b/pages/dr9/files.rst
@@ -169,23 +169,23 @@ counts.
 ==================== ========== =======================================================
 Column               Type       Description
 ==================== ========== =======================================================
-``image_filename``   char[120]  Path to FITS image, e.g. "north/DECam_CP/CP20170729/c4d_170730_045351_ooi_g_v1.fits.fz".
+``image_filename``   char[120]  Path to FITS image, *e.g.* "north/DECam_CP/CP20170729/c4d_170730_045351_ooi_g_v1.fits.fz".
 ``image_hdu``        int16      FITS HDU number in the ``image_filename`` file where this image can be found.
 ``camera``           char[X]    The camera that took this image (X is 7 for "90prime", 6 for "mosaic" and 5 for "decam").
-``expnum``           int64      Exposure number, eg 348224.
-``plver``	     char[8]	Community Pipeline (CP) version number.
-``procdate``	     char[19]	CP processing date.
-``plprocid``	     char[7]	Unique, time-based, CP processing hash - see the `plprocid page`_ for how to convert this to a date.
-``ccdname``          char[X]    CCD name, e.g. "N10", "S7" for DECam (X is 4 for 90prime and mosaic CCDs, and 3 for decam).
+``expnum``           int64      Exposure number, *e.g.* 348224.
+``plver``            char[8]    Community Pipeline (CP) version number.
+``procdate``         char[19]   CP processing date.
+``plprocid``         char[7]    Unique, time-based, CP processing hash - see the `plprocid page`_ for how to convert this to a date.
+``ccdname``          char[X]    CCD name, *e.g.* "N10", "S7" for DECam (X is 4 for 90prime and mosaic CCDs, and 3 for decam).
 ``object``           char[35]   Name listed in the object tag from the CCD header.
 ``propid``           char[10]   Proposal ID of the program that took this image, eg "2014B-0404".
-``filter``           char[1]    Filter used for observation, eg ":math:`g`", ":math:`r`", ":math:`z`".
-``exptime``          float32    Exposure time in seconds, eg 30.
-``mjd_obs``          float64    Date of observation in MJD (in UTC system), eg 56884.99373389.
-``airmass``	     float32	Airmass of observation (measured at the telescope bore-sight).
+``filter``           char[1]    Filter used for observation, *e.g.* ":math:`g`", ":math:`r`", ":math:`z`".
+``exptime``          float32    Exposure time in seconds, *e.g. 30.
+``mjd_obs``          float64    Date of observation in MJD (in UTC system), *e.g.* 56884.99373389.
+``airmass``          float32    Airmass of observation (measured at the telescope bore-sight).
 ``fwhm``             float32    FWHM (in pixels) measured by the CP.
-``width``            int16      Width in pixels of this image, eg 2046.
-``height``           int16      Height in pixels of this image, eg 4096.
+``width``            int16      Width in pixels of this image, *e.g.* 2046.
+``height``           int16      Height in pixels of this image, *e.g.* 4096.
 ``ra_bore``          float64    Telescope boresight RA  of this exposure (deg).
 ``dec_bore``         float64    Telescope boresight Dec of this exposure (deg).
 ``crpix1``           float32    Astrometric header value: X reference pixel.
@@ -196,23 +196,23 @@ Column               Type       Description
 ``cd1_2``            float32    Astrometric header value: transformation matrix.
 ``cd2_1``            float32    Astrometric header value: transformation matrix.
 ``cd2_2``            float32    Astrometric header value: transformation matrix.
-``yshift``	     boolean	(ignore; it's always ``False``).
+``yshift``           boolean    (ignore; it's always ``False``).
 ``ra``               float64    Approximate RA center of this CCD (deg).
 ``dec``              float64    Approximate Dec center of this CCD (deg).
 ``skyrms``           float32    Sky rms for the entire image (in counts/second).
 ``sig1``             float32    Median per-pixel error standard deviation, in nanomaggies.
 ``ccdzpt``           float32    Zeropoint for the CCD (AB mag).
-``zpt``              float32    Median zero point for the entire image (median of all CCDs of the image), eg 25.0927.
+``zpt``              float32    Median zero point for the entire image (median of all CCDs of the image), *e.g.* 25.0927.
 ``ccdraoff``         float32    Median astrometric offset for the CCD <GAIA-Legacy Survey> in arcsec.
 ``ccddecoff``        float32    Median astrometric offset for the CCD <GAIA-Legacy Survey> in arcsec.
-``ccdskycounts``     float32    Mean sky counts level per second per pixel (AVSKY divided by EXPTIME) in the CP-processed frames measured (with iterative rejection) for each CCD in the image section [500:1500,1500:2500].
-``ccdskysb``	     float32	Sky surface brightness (in AB mag/arcsec2).
+``ccdskycounts``     float32    Mean sky counts level per second per pixel (AVSKY divided by EXPTIME) in the CP-processed frames measured (with iterative rejection) for each CCD in the image section [500:1500,1500:2500]. DECam exposure data is in electrons. Mosaic and 90prime are in electrons/sec. Sky counts are normalized to maintain a mean level from the original gain-corrected ADU.
+``ccdskysb``         float32    Sky surface brightness (in AB mag/arcsec2).
 ``ccdrarms``         float32    rms in astrometric offset for the CCD <Gaia-Legacy Survey> in arcsec.
 ``ccddecrms``        float32    rms in astrometric offset for the CCD <Gaia-Legacy Survey> in arcsec.
 ``ccdphrms``         float32    Photometric rms for the CCD (in mag).
 ``phrms``            float32    Median photometric rms across all CCDs in the image (in mag).
-``ccdnastrom``	     int16	Number of stars (after sigma-clipping) used to compute astrometric correction.
-``ccdnphotom``	     int16	Number of Gaia+PS1 stars detected with signal-to-noise ratio greater than five.
+``ccdnastrom``       int16      Number of stars (after sigma-clipping) used to compute astrometric correction.
+``ccdnphotom``       int16      Number of Gaia+PS1 stars detected with signal-to-noise ratio greater than five.
 ``ccd_cuts``         int32      Bit mask describing CCD image quality (see the `DR9 bitmasks page`_).
 ==================== ========== =======================================================
 

--- a/pages/dr9/files.rst
+++ b/pages/dr9/files.rst
@@ -205,8 +205,7 @@ Column               Type       Description
 ``zpt``              float32    Median zero point for the entire image (median of all CCDs of the image), *e.g.* 25.0927.
 ``ccdraoff``         float32    Median astrometric offset for the CCD <GAIA-Legacy Survey> in arcsec.
 ``ccddecoff``        float32    Median astrometric offset for the CCD <GAIA-Legacy Survey> in arcsec.
-``ccdskycounts``     float32    Mean sky counts level per second per pixel (AVSKY divided by EXPTIME) in the CP-processed frames measured (with iterative rejection) for each CCD in the image section [500:1500,1500:2500]. DECam exposure data is in electrons. Mosaic and 90prime are in electrons/sec. Sky counts are normalized to maintain a mean level from the original gain-corrected ADU.
-``ccdskysb``         float32    Sky surface brightness (in AB mag/arcsec2).
+``ccdskycounts``     float32    Mean sky counts level per pixel (AVSKY divided by EXPTIME) in the CP-processed frames measured (with iterative rejection) for each CCD in the image section [500:1500,1500:2500]. DECam exposure data is in electrons. Mosaic and 90prime are in electrons/sec. Sky counts are normalized to maintain a mean level from the original gain-corrected ADU.
 ``ccdrarms``         float32    rms in astrometric offset for the CCD <Gaia-Legacy Survey> in arcsec.
 ``ccddecrms``        float32    rms in astrometric offset for the CCD <Gaia-Legacy Survey> in arcsec.
 ``ccdphrms``         float32    Photometric rms for the CCD (in mag).

--- a/pages/dr9/files.rst
+++ b/pages/dr9/files.rst
@@ -1195,53 +1195,9 @@ We don't expect that most users will need a description of these files, but `con
 Raw Data
 ========
 
-`Astro Data Lab`_ access to raw and calibrated images is now available.
+See the `raw data page`_.
 
-.. _`Astro Data Lab`: https://datalab.noirlab.edu/
-
-Raw and Calibrated Legacy Survey images are available from the `NOIRLab Astro Data Archive`_ through the web
-portal (https://astroarchive.noirlab.edu/portal/search/).
-The input data used to create the
-stacked images, Tractor `catalogs`_, etc. comprise images taken by the dedicated `DESI`_ Legacy Imaging Surveys
-project, as well as other images from the NOIRLab telescopes.
-
-Web Interface
--------------
-
-*Warning:* these instructions are still being updated.
-
-1. Query the `NOIRLab Astro Data archive`_.
-2. From the menu of "Available Collections" on the left, select the desired data release (e.g. LS-DR9).
-3. Under "Data products - Raw data" check "Object".
-4. Optionally, you may select data from specific filters, or restrict the search by other parameters such as sky coordinates, observing date, or exposure time.
-5. Click "Search".
-6. The Results page offers several different ways to download the data. See `the Tutorials page`_ for details.
-
-.. _`NOIRLab Astro Data archive`: https://astroarchive.noirlab.edu/portal/search/
-.. _`the Tutorials page`: http://archive.noao.edu/tutorials/query
-
-
-API Query
----------
-
-*Warning:* these instructions are still being updated.
-
-Following the organization of the Stacked images, Raw and Calibrated images are organized
-by survey brick, which are defined in the file **survey-bricks-dr9.fits.gz** for DR9. Both the main Tractor
-catalogs and Sweep catalogs include the ``BRICKNAME`` keyword (corresponding to ``<brick>`` with
-format ``<AAAa>c<BBB>)``.
-
-For the calibrated images, filenames can be retrieved from the ``IMAGE_FILENAME`` keyword in each brick
-from *legacysurvey*-``<brick>``-*ccds.fits*. Additionally, each *calibrated*/``<AAA>/<brick>``
-contains an ASCII file with a list of ``EXPID`` and ``IMAGE_FILENAME``
-(*legacysurvey*-``<brick>``-*image_filename.txt*).
-``EXPID`` contains the exposure number and the CCD name with the format ``EXPNUM-ccd``.
-There is one entry per CCD. Often, multiple CCDs from a given file are used so there are
-fewer unique filenames than the number of CCDs. Each *legacysurvey*-``<brick>``-*image_filename.txt*
-file contains the number of unique images in the last row (File Count).
-
-Note that the weight map images (the ``oow`` files) are in the same units as :math:`1/\mathtt{skyrms}^2` in the **survey-ccds-<camera>-dr9.fits.gz** files (documented above).
-But, these images need to be multiplied by both gain and ``exptime`` to retrieve units of electrons (for **<camera>** of **mosaic** or **90prime**).
+.. _`raw data page`: ../../rawdata
 
 |
 

--- a/pages/dr9/fringe.rst
+++ b/pages/dr9/fringe.rst
@@ -20,8 +20,8 @@ and the per-exposure fringe scale factors. These fringe templates and scales rep
 `DECaLS`_ reductions are backed out and the new fringe corrections are applied. Later versions of the `CP`_ will likely incorporate new fringe templates, and then
 the correction described here will no longer be necessary.
 
-.. _`Community Pipeline`: https://www.noao.edu/noao/staff/fvaldes/CPDocPrelim/PL201_3.html
-.. _`CP`: https://www.noao.edu/noao/staff/fvaldes/CPDocPrelim/PL201_3.html
+.. _`Community Pipeline`: https://legacy.noirlab.edu/noao/staff/fvaldes/CPDocPrelim/PL201_3.html
+.. _`CP`: https://legacy.noirlab.edu/noao/staff/fvaldes/CPDocPrelim/PL201_3.html
 .. _`DECaLS`: ../../decamls
 .. _`DR8`: ../../DR8
 
@@ -80,7 +80,7 @@ There are several instances for which the new :math:`z\hbox{-}\mathrm{band}` fri
     :height: 400
     :width: 480
 
-.. _`DECam CCD`: http://www.ctio.noao.edu/noao/content/decam-what
+.. _`DECam CCD`: https://noirlab.edu/science/programs/ctio/instruments/Dark-Energy-Camera/characteristics
 
 Code
 ====

--- a/pages/dr9/issues.rst
+++ b/pages/dr9/issues.rst
@@ -21,7 +21,7 @@ Issues with CCDs that may have affected the quality of DECam observations are re
 
 .. _`Legacy Surveys website`: https://github.com/legacysurvey/legacysurvey/issues
 .. _`legacypipe pipeline`: https://github.com/legacysurvey/legacypipe/issues?q=is:issue+sort:updated-desc
-.. _`DECam CCDs page`: http://www.ctio.noao.edu/noao/content/Status-DECam-CCDs
+.. _`DECam CCDs page`: https://noirlab.edu/science/programs/ctio/instruments/Dark-Energy-Camera/Status-DECam-CCDs
 
 The DR9sv "Data Release"
 ------------------------

--- a/pages/dr9/sky.rst
+++ b/pages/dr9/sky.rst
@@ -32,8 +32,8 @@ with `DR9`_, we additionally correct `DECaLS`_ images to account for the residua
     :height: 380
     :width: 380
 
-.. _`DECam Community Pipeline`: https://www.noao.edu/noao/staff/fvaldes/CPDocPrelim/PL201_3.html
-.. _`CP`: https://www.noao.edu/noao/staff/fvaldes/CPDocPrelim/PL201_3.html
+.. _`DECam Community Pipeline`: https://legacy.noirlab.edu/noao/staff/fvaldes/CPDocPrelim/PL201_3.html
+.. _`CP`: https://legacy.noirlab.edu/noao/staff/fvaldes/CPDocPrelim/PL201_3.html
 .. _`DR8`: ../../dr8
 .. _`DR9`: ../../dr9
 .. _`DES`: https://www.darkenergysurvey.org
@@ -92,7 +92,7 @@ Code
 The code used to correct for sky patterns for DR9 of the Legacy Surveys is `available on GitHub`_.
 
 .. _`available on GitHub`: https://github.com/rongpu/desi-misc/tree/master/sky_pattern
-.. _`DECam CCDs`: http://www.ctio.noao.edu/noao/content/decam-what
+.. _`DECam CCDs`: https://noirlab.edu/science/programs/ctio/instruments/Dark-Energy-Camera/characteristics
 
 Additional Information and Products
 ===================================

--- a/pages/dr9/updates.rst
+++ b/pages/dr9/updates.rst
@@ -68,7 +68,7 @@ Algorithmic changes for optical data
 .. _`modified, extended PSF model`: ../psf
 .. _`available for DESI collaborators`: https://desi.lbl.gov/trac/wiki/DecamLegacy/DR9/PSFExAndOuterWings
 .. _`cosmic rays are no longer masked`: https://github.com/legacysurvey/legacypipe/issues/334
-.. _`NOIRLab Community Pipeline`: https://www.noao.edu/noao/staff/fvaldes/CPDocPrelim/PL201_3.html
+.. _`NOIRLab Community Pipeline`: https://legacy.noirlab.edu/noao/staff/fvaldes/CPDocPrelim/PL201_3.html
 .. _`PR 504`: https://github.com/legacysurvey/legacypipe/pull/504
 .. _`criterion used to force a Gaia point source`: https://github.com/legacysurvey/legacypipe/blob/f96311ad56e6eb9878aae378927405745bc1819e/py/legacypipe/reference.py#L196-L197
 .. _`PR 469`: https://github.com/legacysurvey/legacypipe/pull/469
@@ -114,7 +114,7 @@ Data model changes
 
     * ``shape_e1``, ``shape_e1_ivar``, ``shape_e2``, ``shape_e2_ivar``, ``shape_r``, ``shape_r_ivar``
 
-  - The logic behind this change is that, in DR8, the composite ``type`` comprised some fraction (``fracdev``) of a de Vaucouleurs profile, with the remaining fraction being an exponential profile: 
+  - The logic behind this change is that, in DR8, the composite ``type`` comprised some fraction (``fracdev``) of a de Vaucouleurs profile, with the remaining fraction being an exponential profile:
 
     * the ``shapedev_`` and ``shapeexp_`` parameters, in DR8, defined the appropriate parameters for the de Vaucouleurs and exponential profiles. In the event that something was fit with ``type=DEV`` or ``type=EXP``, only the columns that corresponded to the relevant profile would be populated.
 
@@ -189,6 +189,3 @@ Data model changes
 **Footnotes**
 
 .. [1] Here, "pre-burned" means that the region that lies within the confines of the galaxy, cluster or nebula undergoes local source extraction using its own run of Tractor.
-
-
-

--- a/pages/plprocid.rst
+++ b/pages/plprocid.rst
@@ -29,7 +29,7 @@ Then, for example:
 Using Python
 ------------
 
-.. _`NOIRLab Community Pipeline`: https://www.noao.edu/noao/staff/fvaldes/CPDocPrelim/PL201_3.html
+.. _`NOIRLab Community Pipeline`: https://legacy.noirlab.edu/noao/staff/fvaldes/CPDocPrelim/PL201_3.html
 
 At the Python prompt:
 

--- a/pages/rawdata.rst
+++ b/pages/rawdata.rst
@@ -1,0 +1,60 @@
+.. title: Accessing Raw and Calibrated Images
+.. slug: rawdata
+
+.. class:: pull-right well
+
+.. contents::
+
+Data Lab
+========
+
+`Astro Data Lab`_ access to raw and calibrated images is now available.
+
+.. _`Astro Data Lab`: https://datalab.noirlab.edu/
+
+Raw and Calibrated Legacy Survey images are available from the `NOIRLab Astro Data Archive`_ through the web
+portal (https://astroarchive.noirlab.edu/portal/search/). The input data used to create the
+stacked images, Tractor `catalogs`_, etc. comprise images taken by the dedicated `DESI`_ Legacy Imaging Surveys
+project, as well as other images from the NOIRLab telescopes.
+
+.. _`catalogs`: ../dr9/catalogs
+.. _`DESI`: https://www.desi.lbl.gov
+
+
+Web Interface
+=============
+
+*Warning:* these instructions are still being updated.
+
+1. Query the `NOIRLab Astro Data archive`_.
+2. From the menu of "Available Collections" on the left, select the desired data release (*e.g.* LS-DR9).
+3. Under "Data products - Raw data" check "Object".
+4. Optionally, you may select data from specific filters, or restrict the search by other parameters such as sky coordinates, observing date, or exposure time.
+5. Click "Search".
+6. The Results page offers several different ways to download the data.
+
+.. _`NOIRLab Astro Data archive`: https://astroarchive.noirlab.edu/portal/search/
+.. .. _`the Tutorials page`: http://archive.noao.edu/tutorials/query
+
+
+API Query
+=========
+
+*Warning:* these instructions are still being updated.
+
+Following the organization of the Stacked images, Raw and Calibrated images are organized
+by survey brick, which are defined in the file **survey-bricks-dr9.fits.gz** for DR9. Both the main Tractor
+catalogs and Sweep catalogs include the ``BRICKNAME`` keyword (corresponding to ``<brick>`` with
+format ``<AAAa>c<BBB>)``.
+
+For the calibrated images, filenames can be retrieved from the ``IMAGE_FILENAME`` keyword in each brick
+from *legacysurvey*-``<brick>``-*ccds.fits*. Additionally, each *calibrated*/``<AAA>/<brick>``
+contains an ASCII file with a list of ``EXPID`` and ``IMAGE_FILENAME``
+(*legacysurvey*-``<brick>``-*image_filename.txt*).
+``EXPID`` contains the exposure number and the CCD name with the format ``EXPNUM-ccd``.
+There is one entry per CCD. Often, multiple CCDs from a given file are used so there are
+fewer unique filenames than the number of CCDs. Each *legacysurvey*-``<brick>``-*image_filename.txt*
+file contains the number of unique images in the last row (File Count).
+
+Note that the weight map images (the ``oow`` files) are in the same units as :math:`1/\mathtt{skyrms}^2` in the **survey-ccds-<camera>-dr9.fits.gz** files (documented above).
+But, these images need to be multiplied by both gain and ``exptime`` to retrieve units of electrons (for **<camera>** of **mosaic** or **90prime**).


### PR DESCRIPTION
This PR removes all possible `noao.edu` URLs and replaces them with valid `noirlab.edu` URLs wherever possible. 

There are still a handful of `ftp` URLs that need to be dealt with, so don't merge yet.

In order to simplify further documentation of raw data access, I have moved all raw data documentation to a single file `pages/rawdata.rst`.

Side note: In addition to an older version of Nikola, `docutils<0.17` must be installed for the gallery pages to render correctly.