### PR TITLE
NOBS is slightly different in the Tractor vs. random catalogs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,7 +3,7 @@
 ## 9.0.7 (DR9, unreleased)
 
 - Planned: actually update the raw and CP-processed data access instructions
-  ([#143](https://github.com/legacysurvey/legacysurvey/issues/149)).
+  ([#143](https://github.com/legacysurvey/legacysurvey/issues/143)).
 
 ## 9.0.6 (DR9, 2022-02-16)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,13 +2,13 @@
 
 ## 9.0.7 (DR9, unreleased)
 
+- Add a dr9 known issue about NOBS in the Tractor vs. random catalogs
+  ([PR#153](https://github.com/legacysurvey/legacysurvey/pull/153)).
 - Planned: actually update the raw and CP-processed data access instructions
   ([#143](https://github.com/legacysurvey/legacysurvey/issues/143)).
 
 ## 9.0.6 (DR9, 2022-02-16)
 
-- Add a dr9 known issue about NOBS in the Tractor vs. random catalogs
-  ([PR#153](https://github.com/legacysurvey/legacysurvey/pull/153)).
 - Replace `noao.edu` with `noirlab.edu` wherever possible; move raw
   data access instructions into a unified, top-level page
   ([PR#150](https://github.com/legacysurvey/legacysurvey/pull/150)).

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,8 @@
 
 ## 9.0.6 (DR9, 2022-02-16)
 
+- Add a dr9 known issue about NOBS in the Tractor vs. random catalogs
+  ([PR#153](https://github.com/legacysurvey/legacysurvey/pull/153)).
 - Replace `noao.edu` with `noirlab.edu` wherever possible; move raw
   data access instructions into a unified, top-level page
   ([PR#150](https://github.com/legacysurvey/legacysurvey/pull/150)).

--- a/pages/dr9/catalogs.rst
+++ b/pages/dr9/catalogs.rst
@@ -136,13 +136,13 @@ Name                                  Type         Units                 Descrip
 ``mw_transmission_w2``	              float32                            Galactic transmission in :math:`W2` filter in linear units [0, 1]
 ``mw_transmission_w3``	              float32                            Galactic transmission in :math:`W3` filter in linear units [0, 1]
 ``mw_transmission_w4``	              float32                            Galactic transmission in :math:`W4` filter in linear units [0, 1]
-``nobs_g``                            int16                              Number of images that contribute to the central pixel in :math:`g`: filter for this object (not profile-weighted)
-``nobs_r``                            int16                              Number of images that contribute to the central pixel in :math:`r`: filter for this object (not profile-weighted)
-``nobs_z``                            int16                              Number of images that contribute to the central pixel in :math:`z`: filter for this object (not profile-weighted)
-``nobs_w1``                           int16                              Number of images that contribute to the central pixel in :math:`W1`: filter for this object (not profile-weighted)
-``nobs_w2``                           int16                              Number of images that contribute to the central pixel in :math:`W2`: filter for this object (not profile-weighted)
-``nobs_w3``                           int16                              Number of images that contribute to the central pixel in :math:`W3`: filter for this object (not profile-weighted)
-``nobs_w4``                           int16                              Number of images that contribute to the central pixel in :math:`W4`: filter for this object (not profile-weighted)
+``nobs_g``                            int16                              Number of images that contribute to the central pixel in :math:`g` filter for this object (not profile-weighted)
+``nobs_r``                            int16                              Number of images that contribute to the central pixel in :math:`r` filter for this object (not profile-weighted)
+``nobs_z``                            int16                              Number of images that contribute to the central pixel in :math:`z` filter for this object (not profile-weighted)
+``nobs_w1``                           int16                              Number of images that contribute to the central pixel in :math:`W1` filter for this object (not profile-weighted)
+``nobs_w2``                           int16                              Number of images that contribute to the central pixel in :math:`W2` filter for this object (not profile-weighted)
+``nobs_w3``                           int16                              Number of images that contribute to the central pixel in :math:`W3` filter for this object (not profile-weighted)
+``nobs_w4``                           int16                              Number of images that contribute to the central pixel in :math:`W4` filter for this object (not profile-weighted)
 ``rchisq_g``                          float32                            Profile-weighted |chi|\ |sup2| of model fit normalized by the number of pixels in :math:`g`
 ``rchisq_r``                          float32                            Profile-weighted |chi|\ |sup2| of model fit normalized by the number of pixels in :math:`r`
 ``rchisq_z``                          float32                            Profile-weighted |chi|\ |sup2| of model fit normalized by the number of pixels in :math:`z`

--- a/pages/dr9/files.rst
+++ b/pages/dr9/files.rst
@@ -180,7 +180,7 @@ Column               Type       Description
 ``object``           char[35]   Name listed in the object tag from the CCD header.
 ``propid``           char[10]   Proposal ID of the program that took this image, eg "2014B-0404".
 ``filter``           char[1]    Filter used for observation, *e.g.* ":math:`g`", ":math:`r`", ":math:`z`".
-``exptime``          float32    Exposure time in seconds, *e.g. 30.
+``exptime``          float32    Exposure time in seconds, *e.g.* 30.
 ``mjd_obs``          float64    Date of observation in MJD (in UTC system), *e.g.* 56884.99373389.
 ``airmass``          float32    Airmass of observation (measured at the telescope bore-sight).
 ``fwhm``             float32    FWHM (in pixels) measured by the CP.

--- a/pages/dr9/issues.rst
+++ b/pages/dr9/issues.rst
@@ -57,3 +57,24 @@ A list of the affected bricks `is available here`_.
 `Blobmodel images`_ were intended to be compressed, and are named with a ``.fits.fz`` suffix, but they are not actually compressed.
 
 .. _`Blobmodel images`: ../files/#image-stacks-region-coadd
+
+
+``NOBS`` differs between the Tractor catalogs and random catalogs
+-----------------------------------------------------------------
+
+Quantities named ``nobs_x`` (where ``x`` is any of the Legacy Surveys imaging bands) in the `Tractor catalogs`_ (and derived
+products such as the sweep files) are slightly different to the ``NOBS_X`` quantities in the `random catalogs`_.
+
+The `Tractor catalogs`_ ``nobs`` columns count *all* pixels overlapping each brick pixel, even if the pixel is masked. In contrast,
+the `random catalogs`_ are derived from the ``nexp`` `coadded stacks`_, which only count pixels where the inverse variances are positive.
+This means, for instance, that the ``nexp`` stacks ignore both masked pixels and pixels that have zero weight passed forwards from the
+Community Pipeline.
+
+The result of this discrepancy is that a few percent of objects in the `Tractor catalogs`_ have different values of ``nobs`` than would
+be expected when deriving ``NOBS`` from the same location in the ``nexp`` `coadded stacks`_. Conveniently, the ``nobs`` values in the `Tractor catalogs`_
+are (almost) always larger than what would be derived from the ``nexp`` `coadded stacks`_. This means that constraints based on a minimum number of
+observations in a given filter will always result in reproducible survey geometry, at the expensive of rejecting a few per cent of sources.
+
+.. _`Tractor catalogs`: ../catalogs
+.. _`random catalogs`: ../files/#random-catalogs-randoms
+.. _`coadded stacks`: ../files/#image-stacks-region-coadd

--- a/pages/dr9/issues.rst
+++ b/pages/dr9/issues.rst
@@ -63,7 +63,7 @@ A list of the affected bricks `is available here`_.
 -----------------------------------------------------------------
 
 Quantities named ``nobs_x`` (where ``x`` is any of the Legacy Surveys imaging bands) in the `Tractor catalogs`_ (and derived
-products such as the sweep files) are slightly different to the ``NOBS_X`` quantities in the `random catalogs`_.
+products such as the sweep files) are slightly different from the ``NOBS_X`` quantities in the `random catalogs`_.
 
 The `Tractor catalogs`_ ``nobs`` columns count *all* pixels overlapping each brick pixel, even if the pixel is masked. In contrast,
 the `random catalogs`_ are derived from the ``nexp`` `coadded stacks`_, which only count pixels where the inverse variances are positive.

--- a/pages/dr9/issues.rst
+++ b/pages/dr9/issues.rst
@@ -72,8 +72,8 @@ Community Pipeline.
 
 The result of this discrepancy is that a few percent of objects in the `Tractor catalogs`_ have different values of ``nobs`` than would
 be expected when deriving ``NOBS`` from the same location in the ``nexp`` `coadded stacks`_. Conveniently, the ``nobs`` values in the `Tractor catalogs`_
-are (almost) always larger than what would be derived from the ``nexp`` `coadded stacks`_. This means that constraints based on a minimum number of
-observations in a given filter will always result in reproducible survey geometry, at the expensive of rejecting a few per cent of sources.
+are (almost) always larger than what would be derived from the ``nexp`` `coadded stacks`_. This means that constraints based on a minimum ``nexp`` value
+in a given filter will always result in reproducible survey geometry, at the expense of rejecting a small fraction (typically <1%) of sources.
 
 .. _`Tractor catalogs`: ../catalogs
 .. _`random catalogs`: ../files/#random-catalogs-randoms


### PR DESCRIPTION
This PR adds a known issue to the dr9 page detailing how the `NOBS` quantity differs between the Tractor catalogs and the random catalogs. 