### PR TITLE
Update the dr8 and dr9 bitmasks pages to include i-band bits

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## 9.0.8 (DR9, unreleased)
 
+- Add new i-band ``MASKBITS`` values (``SATUR_I`` and ``ALLMASK_I``)
+  ([PR#154](https://github.com/legacysurvey/legacysurvey/pull/154)).
 - Planned: actually update the raw and CP-processed data access instructions
   ([#143](https://github.com/legacysurvey/legacysurvey/issues/143)).
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,11 +1,14 @@
 # legacysurvey Change Log
 
+## 9.1.0 (DR9, unreleased)
+
+- Planned: actually update the raw and CP-processed data access instructions
+  ([#143](https://github.com/legacysurvey/legacysurvey/issues/143)).
+
 ## 9.0.8 (DR9, unreleased)
 
 - Add new i-band ``MASKBITS`` values (``SATUR_I`` and ``ALLMASK_I``)
   ([PR#154](https://github.com/legacysurvey/legacysurvey/pull/154)).
-- Planned: actually update the raw and CP-processed data access instructions
-  ([#143](https://github.com/legacysurvey/legacysurvey/issues/143)).
 
 ## 9.0.7 (DR9, 2022-02-16)
 

--- a/pages/dr8/bitmasks.rst
+++ b/pages/dr8/bitmasks.rst
@@ -53,6 +53,8 @@ Bit Name          Description
 11  ``MEDIUM``    touches a pixel within the locus of a `radius-magnitude relation for Gaia DR2`_ stars `to G < 16`_
 12  ``GALAXY``    touches a pixel in an `SGA`_ large galaxy
 13  ``CLUSTER``   touches a pixel in a globular cluster
+14  ``SATUR_I``   touches a pixel that was saturated in at least one :math:`i`-band image
+15  ``ALLMASK_I`` touches a pixel that has any of the ``ALLMASK_I`` bits set
 === ============= ===============================
 
 .. _`radius-magnitude relation for Tycho-2 stars`: https://github.com/legacysurvey/legacypipe/blob/65d71a6b0d0cc2ab94d497770346ff6241020f80/py/legacypipe/reference.py#L258

--- a/pages/dr8/bitmasks.rst
+++ b/pages/dr8/bitmasks.rst
@@ -53,8 +53,8 @@ Bit Name          Description
 11  ``MEDIUM``    touches a pixel within the locus of a `radius-magnitude relation for Gaia DR2`_ stars `to G < 16`_
 12  ``GALAXY``    touches a pixel in an `SGA`_ large galaxy
 13  ``CLUSTER``   touches a pixel in a globular cluster
-14  ``SATUR_I``   touches a pixel that was saturated in at least one :math:`i`-band image
-15  ``ALLMASK_I`` touches a pixel that has any of the ``ALLMASK_I`` bits set
+14  ``SATUR_I``   touches a pixel that was saturated in at least one :math:`i`-band image (always zero prior to DR10)
+15  ``ALLMASK_I`` touches a pixel that has any of the ``ALLMASK_I`` bits set (always zero prior to DR10)
 === ============= ===============================
 
 .. _`radius-magnitude relation for Tycho-2 stars`: https://github.com/legacysurvey/legacypipe/blob/65d71a6b0d0cc2ab94d497770346ff6241020f80/py/legacypipe/reference.py#L258

--- a/pages/dr9/bitmasks.rst
+++ b/pages/dr9/bitmasks.rst
@@ -33,6 +33,8 @@ Bit Name          Description
 11  ``MEDIUM``    touches a pixel within the locus of a `radius-magnitude relation`_. Set for Gaia stars with `G < 16`_. The ``MEDIUM`` radius is twice the ``BRIGHT`` radius at the same magnitude.
 12  ``GALAXY``    touches a pixel in an `SGA`_ large galaxy
 13  ``CLUSTER``   touches a pixel in a globular cluster
+14  ``SATUR_I``   touches a pixel that was saturated in at least one :math:`i`-band image
+15  ``ALLMASK_I`` touches a pixel that has any of the ``ALLMASK_I`` bits set
 === ============= ===============================
 
 .. _`legacypipe bitmask definitions`: https://github.com/legacysurvey/legacypipe/blob/master/py/legacypipe/bits.py

--- a/pages/dr9/bitmasks.rst
+++ b/pages/dr9/bitmasks.rst
@@ -33,8 +33,8 @@ Bit Name          Description
 11  ``MEDIUM``    touches a pixel within the locus of a `radius-magnitude relation`_. Set for Gaia stars with `G < 16`_. The ``MEDIUM`` radius is twice the ``BRIGHT`` radius at the same magnitude.
 12  ``GALAXY``    touches a pixel in an `SGA`_ large galaxy
 13  ``CLUSTER``   touches a pixel in a globular cluster
-14  ``SATUR_I``   touches a pixel that was saturated in at least one :math:`i`-band image
-15  ``ALLMASK_I`` touches a pixel that has any of the ``ALLMASK_I`` bits set
+14  ``SATUR_I``   touches a pixel that was saturated in at least one :math:`i`-band image (always zero prior to DR10)
+15  ``ALLMASK_I`` touches a pixel that has any of the ``ALLMASK_I`` bits set (always zero prior to DR10)
 === ============= ===============================
 
 .. _`legacypipe bitmask definitions`: https://github.com/legacysurvey/legacypipe/blob/master/py/legacypipe/bits.py


### PR DESCRIPTION
This is a simple PR that updates the dr8 and dr9 bitmasks pages to include ``SATUR_I`` and ``ALLMASK_I`` in the ``MASKBITS`` bitmask.

Although these won't be populated until DR10 of the Legacy Surveys, it's useful for people to be aware of their existence now — and they would simply be zero-valued for DR8 and DR9.