### PR TITLE
Update boilerplate on entry index page for NOIRLab rather than NOAO

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,7 +7,7 @@
 - *Planned*: actually update the raw and CP-processed data access instructions
   ([#143](https://github.com/legacysurvey/legacysurvey/issues/143)).
 - Update boilerplate on entry index page for NOIRLab rather than NOAO
-  ([PR#166](https://github.com/legacysurvey/legacysurvey/pull/167)).
+  ([PR#167](https://github.com/legacysurvey/legacysurvey/pull/167)).
 
 ## 10.0.1 (DR10, 2023-01-05)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,8 @@
   ([#152](https://github.com/legacysurvey/legacysurvey/issues/152)).
 - *Planned*: actually update the raw and CP-processed data access instructions
   ([#143](https://github.com/legacysurvey/legacysurvey/issues/143)).
+- Update boilerplate on entry index page for NOIRLab rather than NOAO
+  ([PR#166](https://github.com/legacysurvey/legacysurvey/pull/167)).
 
 ## 10.0.1 (DR10, 2023-01-05)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,11 +1,14 @@
 # legacysurvey Change Log
 
-## 10.0.2 (DR10, unreleased)
+## 10.1.0 (DR10, planned)
 
 - *Planned*: correct units for `ccdskycounts`
-  ([#152](https://github.com/legacysurvey/legacysurvey/issues/152)).
+  ([issue #152](https://github.com/legacysurvey/legacysurvey/issues/152)).
 - *Planned*: actually update the raw and CP-processed data access instructions
-  ([#143](https://github.com/legacysurvey/legacysurvey/issues/143)).
+  ([issue #143](https://github.com/legacysurvey/legacysurvey/issues/143)).
+
+## 10.0.2 (DR10, unreleased)
+
 - Update boilerplate on entry index page for NOIRLab rather than NOAO
   ([PR#167](https://github.com/legacysurvey/legacysurvey/pull/167)).
 

--- a/pages/index.rst
+++ b/pages/index.rst
@@ -69,7 +69,7 @@
    Energy Office of Science High Energy Physics.*
 
    *NSF's NOIRLab (National Optical-Infrared Astronomy Research
-   Laboratory) the US center for ground-based optical astronomy,
+   Laboratory), the US center for ground-based optical astronomy,
    operates the international Gemini Observatory (a facility of NSF
    NRC-Canada, ANID-Chile, MCTIC-Brazil, MINCyT-Argentina, and
    KASI-Republic of Korea), Kitt Peak National Observatory (KPNO),

--- a/pages/index.rst
+++ b/pages/index.rst
@@ -69,8 +69,8 @@
    Energy Office of Science High Energy Physics.*
 
    *NSF's NOIRLab (National Optical-Infrared Astronomy Research
-   Laboratory), the US center for ground-based optical astronomy,
-   operates the international Gemini Observatory (a facility of NSF
+   Laboratory), the US center for ground-based optical-infrared astronomy,
+   operates the international Gemini Observatory (a facility of NSF,
    NRC-Canada, ANID-Chile, MCTIC-Brazil, MINCyT-Argentina, and
    KASI-Republic of Korea), Kitt Peak National Observatory (KPNO),
    Cerro Tololo Inter-American Observatory (CTIO), the Community
@@ -78,7 +78,7 @@
    cooperation with DOE's SLAC National Accelerator Laboratory). It is
    managed by the Association of Universities for Research in Astronomy
    (AURA) under a cooperative agreement with NSF and is headquartered
-   in Tucson, Arizona*
+   in Tucson, Arizona.*
 
    *The National Energy Research Scientific Computing Center, which is
    supported by the Office of Science of the U.S. Department of Energy

--- a/pages/index.rst
+++ b/pages/index.rst
@@ -68,10 +68,17 @@
    *The LBNL Physics Division is supported by the U.S. Department of
    Energy Office of Science High Energy Physics.*
 
-   *The Cerro Tololo Inter-American Observatory and the National
-   Optical Astronomy Observatory are operated by the Association
-   of Universities for Research in Astronomy (AURA) under cooperative
-   agreement with the National Science Foundation.*
+   *NSF's NOIRLab (National Optical-Infrared Astronomy Research
+   Laboratory) the US center for ground-based optical astronomy,
+   operates the international Gemini Observatory (a facility of NSF
+   NRC-Canada, ANID-Chile, MCTIC-Brazil, MINCyT-Argentina, and
+   KASI-Republic of Korea), Kitt Peak National Observatory (KPNO),
+   Cerro Tololo Inter-American Observatory (CTIO), the Community
+   Science and Data Center (CSDC), and Vera C. Rubin Observatory (in
+   cooperation with DOE's SLAC National Accelerator Laboratory). It is
+   managed by the Association of Universities for Research in Astronomy
+   (AURA) under a cooperative agreement with NSF and is headquartered
+   in Tucson, Arizona*
 
    *The National Energy Research Scientific Computing Center, which is
    supported by the Office of Science of the U.S. Department of Energy


### PR DESCRIPTION
NOIRLab reached out asking if we could update the boilerplate on the main page to reflect NOIRLab-appropriate language instead of the older NOAO-appropriate language.

This PR makes that change.
