### PR TITLE
Add known issue about DR10 brick summary file and update corresponding table of source counts

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,11 +1,18 @@
 # legacysurvey Change Log
 
-## 10.1.2 (DR10, planned)
+## 10.1.3 (DR10, planned)
 
 - *Planned*: correct units for `ccdskycounts`
   ([issue #152](https://github.com/legacysurvey/legacysurvey/issues/152)).
 - *Planned*: actually update the raw and CP-processed data access instructions
   ([issue #143](https://github.com/legacysurvey/legacysurvey/issues/143)).
+
+## 10.1.2 (DR10, 2024-01-XX)
+
+- Add a known issue describing updates to the brick summary files
+  ([PR#177](https://github.com/legacysurvey/legacysurvey/pull/177)):
+    - Also update table of sources by morphological type on DR10 description page.
+    - Addresses [issue #176](https://github.com/legacysurvey/legacysurvey/issues/176).
 
 ## 10.1.1 (DR10, 2023-09-28)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,7 +7,7 @@
 - *Planned*: actually update the raw and CP-processed data access instructions
   ([issue #143](https://github.com/legacysurvey/legacysurvey/issues/143)).
 
-## 10.1.2 (DR10, 2024-01-XX)
+## 10.1.2 (DR10, 2024-01-03)
 
 - Add a known issue describing updates to the brick summary files
   ([PR#177](https://github.com/legacysurvey/legacysurvey/pull/177)):

--- a/pages/dr10/description.rst
+++ b/pages/dr10/description.rst
@@ -394,21 +394,26 @@ No optical flux is assigned to "DUP" sources, but they are retained to ensure th
 `Tractor`_ preferred and fit a different source based on the deeper Legacy Surveys imaging.
 The total numbers of the different morphological types in DR10 are:
 
+.. note::
+   This table was updated in early 2024 to correct for a `bug in the brick-level summary statics file`_.
+
 ======================= ==============
 Primary Objects of Type Unique Sources
 ======================= ==============
-*All*                    2,826,169,461
-``PSF``                  1,345,771,671
-``REX``                  1,122,268,233
-``EXP``                    225,234,618
-``DEV``                     83,907,237
-``SER``                     48,696,586
+*All*                    2,827,055,986
+``PSF``                  1,346,165,723
+``REX``                  1,122,579,568
+``EXP``                    225,321,618
+``DEV``                     83,968,261
+``SER``                     48,729,700
 ``DUP``                        291,116
 ======================= ==============
 
 *Primary* objects, here, specifically refers to sources for which ``BRICK_PRIMARY==True``
 (the totals are derived from the *total number* counts in the `survey bricks summary file`_).
 See `DR9`_ for source counts in the northern footprint of the Legacy Surveys.
+
+.. _`bug in the brick-level summary statics file`: ../issues/#updates-to-the-brick-level-summary-statistics-files
 
 The decision to retain an object in the catalog and to re-classify it using
 models more complicated than a point source is made using the penalized
@@ -434,7 +439,7 @@ The fluxes are not constrained to be positive-valued.  This allows the fitting o
 very low signal-to-noise sources without introducing biases at the faint end.  It
 also allows the stacking of fluxes at the catalog level.
 
-.. _`survey bricks summary file`: ../files/#survey-bricks-dr10-south-fits-gz
+.. _`survey bricks summary file`: ../files/#south-survey-bricks-dr10-south-fits-gz
 
 Tractor Implementation Details
 ==============================

--- a/pages/dr10/issues.rst
+++ b/pages/dr10/issues.rst
@@ -76,18 +76,33 @@ are in the directories ``10.0``, ``10.0-extra`` and ``10.0-lightcurves`` and the
 ``10.1``, ``10.1-extra`` and ``10.1-lightcurves``. The original and updated versions of the external-match files are both in the
 ``external`` directory, but the original files contain the string ``dr10`` and the updated files contain the string ``dr10.1``.
 
-
 Large galaxies missing from the Siena Galaxy Atlas
 --------------------------------------------------
 Fifty-two galaxies were overlooked in the version of the `Siena Galaxy Atlas`_ (SGA) used to process DR10. The upshot of this oversight
 is that these galaxies were not flagged as ``GALAXY`` in the `MASKBITS bitmask`_. Further details are provided in `legacypipe issue #680`_.
 Note that these fifty-two galaxies `were` included in the publicly released version of the SGA.
 
+Updates to the brick-level summary statistics files
+---------------------------------------------------
+The initial `brick-level summary file`_ released with DR10 contained an incorrect accounting of the number of sources in some bricks.
+This was likely caused by processing results before all relevant files in the release were finalized and rsynced. Multiple columns
+in the summary file were inaccurate to varying degrees, including
+``nexphist_*``, ``nobjs``, ``npsf``, ``nrex``, ``nexp``, ``ndev``, ``nser``, ``psfsize_*``, ``psfdepth_*``, ``galdepth_*``, ``ebv``, ``trans_*``, ``cosky_*``, ``ext_*`` and ``wise_nobs``.
+In December of 2023, we completely replaced this file. The table of the `number of sources of each morphological type`_ on the description page
+was also updated to reflect the new information.
+
+The `dr10-south-depth.fits.gz`_ and `dr10-south-depth-summary.fits.gz`_ files were also updated in December of 2023, although
+all of the changes in these summary files were caused by fixes to the 598 bricks affected by the ``SUB_BLOB`` bug (described above).
+
 
 .. _`legacypipe issue #680`: https://github.com/legacysurvey/legacypipe/issues/680
 .. _`Siena Galaxy Atlas`: ../../sga/sga2020
 .. _`Tractor catalogs`: ../catalogs
 .. _`tractor`: ../catalogs
+.. _`number of sources of each morphological type`: ../description/#morphological-classification
+.. _`dr10-south-depth.fits.gz`: ../files/#south-dr10-south-depth-fits-gz
+.. _`dr10-south-depth-summary.fits.gz`: ../files/#south-dr10-south-depth-summary-fits-gz
+.. _`brick-level summary file`: ../files/#south-survey-bricks-dr10-south-fits-gz
 .. _`coadd stacks`: ../files/#image-stacks-south-coadd
 .. _`sweep files`: ../files/#sweep-catalogs-south-sweep
 .. _`random catalogs`: ../files/#random-catalogs-randoms


### PR DESCRIPTION
This PR adds a known issue describing updates to the brick summary files, and, in particular, to the ``survey-bricks-dr10-south-fits.gz`` summary file. This file had to be replaced due to inaccurate values in various columns. These inaccuracies were likely caused by calculating summary statistics before bricks had been rsynced and finalized.

This PR also updates the table of sources by morphological type on the DR10 description page to reflect the values in the new ``survey-bricks-dr10-south-fits.gz`` summary file.

This PR should address #176.